### PR TITLE
[#22] Fix formatter's import alignment rule

### DIFF
--- a/api/.prettierrc
+++ b/api/.prettierrc
@@ -1,7 +1,10 @@
 {
-    "tabWidth": 2,
-    "semi": true,
-    "trailingComma": "none",
-    "singleQuote": true,
-    "printWidth": 80
+  "tabWidth": 2,
+  "semi": true,
+  "trailingComma": "none",
+  "singleQuote": true,
+  "printWidth": 80,
+  "importOrder": ["^@src/(.*)$"],
+  "importOrderSeparation": true,
+  "importOrderSortSpecifiers": true
 }

--- a/api/src/config/loader.ts
+++ b/api/src/config/loader.ts
@@ -1,6 +1,7 @@
+import config from 'config';
+
 import { Config, ConfigHttp, ConfigLogger } from '@src/config/types';
 import { LoggerConfig } from '@src/logger/types';
-import config from 'config';
 
 export function configLoad(): Config {
   try {

--- a/api/src/config/types.ts
+++ b/api/src/config/types.ts
@@ -1,4 +1,4 @@
-import { LogLevel, LogFormat } from '@src/logger/types';
+import { LogFormat, LogLevel } from '@src/logger/types';
 
 export interface Config {
   env: string;

--- a/api/src/logger/logger.ts
+++ b/api/src/logger/logger.ts
@@ -1,11 +1,12 @@
-import { LoggerConfig, LogFormat } from '@src/logger/types';
 import {
-  LoggerOptions,
   Logger,
+  LoggerOptions,
   createLogger,
   format,
   transports
 } from 'winston';
+
+import { LogFormat, LoggerConfig } from '@src/logger/types';
 
 // The available log levels are described in the link below.
 // https://github.com/winstonjs/winston#logging-levels

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -1,4 +1,4 @@
-import { configLoad, buildLoggerConfig } from '@src/config/loader';
+import { buildLoggerConfig, configLoad } from '@src/config/loader';
 import { loggerInitialize } from '@src/logger/logger';
 
 function main() {

--- a/api/test/config/loader.test.ts
+++ b/api/test/config/loader.test.ts
@@ -1,5 +1,6 @@
-import { configLoad, buildLoggerConfig } from '@src/config/loader';
 import config from 'config';
+
+import { buildLoggerConfig, configLoad } from '@src/config/loader';
 
 describe('Test config loader', () => {
   it('should load valid configurations from a test.yaml', () => {


### PR DESCRIPTION
Resolves #22

# Changes

- Set formatter's import alignment rule
    1. Set import sort order with regular expression
    2. New line separation between sorted import declarations group
    3. Set alignment between import specifiers