### PR TITLE
[#34] Prevent spoofing client IP

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -13,7 +13,6 @@
                 "express": "^4.18.2",
                 "express-async-errors": "^3.1.1",
                 "js-yaml": "^4.1.0",
-                "request-ip": "^3.3.0",
                 "rimraf": "^5.0.0",
                 "tsc-alias": "^1.8.5",
                 "tsconfig-paths": "^4.2.0",
@@ -6298,11 +6297,6 @@
             "engines": {
                 "node": ">=8.10.0"
             }
-        },
-        "node_modules/request-ip": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-3.3.0.tgz",
-            "integrity": "sha512-cA6Xh6e0fDBBBwH77SLJaJPBmD3nWVAcF9/XAcsrIHdjhFzFiB5aNQFytdjCGPezU3ROwrR11IddKAM08vohxA=="
         },
         "node_modules/require-directory": {
             "version": "2.1.1",

--- a/api/package.json
+++ b/api/package.json
@@ -44,7 +44,6 @@
         "express": "^4.18.2",
         "express-async-errors": "^3.1.1",
         "js-yaml": "^4.1.0",
-        "request-ip": "^3.3.0",
         "rimraf": "^5.0.0",
         "tsc-alias": "^1.8.5",
         "tsconfig-paths": "^4.2.0",

--- a/api/src/controller/http/middleware.ts
+++ b/api/src/controller/http/middleware.ts
@@ -18,7 +18,7 @@ export class Middleware {
       this.logger.http('Access log', {
         method: req.method,
         url: req.originalUrl,
-        addr: req.clientIp,
+        addr: req.ip,
         proto: `${req.protocol}/${req.httpVersion}`,
         contentLength: req.headers['content-length'],
         userAgent: req.headers['user-agent'],

--- a/api/src/controller/http/server.ts
+++ b/api/src/controller/http/server.ts
@@ -22,7 +22,7 @@ export class HttpServer {
     return new Promise((resolve) => {
       const app = express();
       app.disable('x-powered-by');
-      app.use(requestIp.mw());
+      app.set('trust proxy', 0);
       app.use(this.middleware.accessLog);
       app.use('/api', this.getRouters());
       app.use(this.middleware.handleError);


### PR DESCRIPTION
Resolves #34 

# Changes

- Remove unused package
    - `requestIp`
- Added option to prevent spoofing client IP
    - `trust proxy`