### PR TITLE
[#25] Fixes bad function names

### DIFF
--- a/api/src/config/loader.ts
+++ b/api/src/config/loader.ts
@@ -9,7 +9,7 @@ import {
 import { HttpConfig } from '@src/controller/http/types';
 import { LoggerConfig } from '@src/logger/types';
 
-export function configLoad(): Config {
+export function loadConfig(): Config {
   try {
     return {
       env: config.get<string>('env'),

--- a/api/src/logger/logger.ts
+++ b/api/src/logger/logger.ts
@@ -10,7 +10,7 @@ import { LogFormat, LoggerConfig } from '@src/logger/types';
 
 // The available log levels are described in the link below.
 // https://github.com/winstonjs/winston#logging-levels
-export function loggerInitialize(config: LoggerConfig): Logger {
+export function initializeLogger(config: LoggerConfig): Logger {
   let loggerOption: LoggerOptions;
   try {
     if (config.format === LogFormat.JSON) {

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -1,22 +1,22 @@
 import {
   buildHttpConfig,
   buildLoggerConfig,
-  configLoad
+  loadConfig
 } from '@src/config/loader';
-import { loggerInitialize } from '@src/logger/logger';
+import { initializeLogger } from '@src/logger/logger';
 
 import { HttpServer } from '@controller/http/server';
 
 async function main() {
   let config;
   try {
-    config = configLoad();
+    config = loadConfig();
   } catch (e) {
     console.error(`${e}`);
     process.exit(1);
   }
 
-  const logger = loggerInitialize(buildLoggerConfig(config));
+  const logger = initializeLogger(buildLoggerConfig(config));
   const httpServer = new HttpServer(logger, buildHttpConfig(config));
   await httpServer.start();
   // await httpServer.close();

--- a/api/test/config/loader.test.ts
+++ b/api/test/config/loader.test.ts
@@ -3,12 +3,12 @@ import config from 'config';
 import {
   buildHttpConfig,
   buildLoggerConfig,
-  configLoad
+  loadConfig
 } from '@src/config/loader';
 
 describe('Test config loader', () => {
   it('should load valid configurations from a test.yaml', () => {
-    expect(configLoad()).toStrictEqual({
+    expect(loadConfig()).toStrictEqual({
       env: 'test',
       timeout: { shutdownSeconds: 30 },
       http: { host: '127.0.0.1', port: 0 },
@@ -18,7 +18,7 @@ describe('Test config loader', () => {
 
   it('should not override fields by env variable', () => {
     process.env.env = 'production';
-    const config = configLoad();
+    const config = loadConfig();
     expect(config.env).not.toEqual('production');
   });
 
@@ -27,14 +27,14 @@ describe('Test config loader', () => {
       throw new Error('');
     });
     expect(() => {
-      configLoad();
+      loadConfig();
     }).toThrow();
   });
 });
 
 describe('Test build logger config', () => {
   it('should build valid logger config from a test.yaml', () => {
-    expect(buildLoggerConfig(configLoad())).toStrictEqual({
+    expect(buildLoggerConfig(loadConfig())).toStrictEqual({
       deployment: 'test',
       level: 'silly',
       format: 'text'
@@ -44,7 +44,7 @@ describe('Test build logger config', () => {
 
 describe('Test build http config', () => {
   it('should build valid http config from a test.yaml', () => {
-    expect(buildHttpConfig(configLoad())).toStrictEqual({
+    expect(buildHttpConfig(loadConfig())).toStrictEqual({
       env: 'test',
       host: '127.0.0.1',
       port: 0


### PR DESCRIPTION
Resolves #25 

# Changes

- Rename functions
    - `configLoad` -> `loadConfig`
    - `loggerInitialize` -> `initializeLogger`