### PR TITLE
[#26] Add import module specifier setting

### DIFF
--- a/Mr-C.code-workspace
+++ b/Mr-C.code-workspace
@@ -1,0 +1,10 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {
+		"typescript.preferences.importModuleSpecifier": "non-relative"
+	}
+}

--- a/api/.vscode/settings.json
+++ b/api/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.preferences.importModuleSpecifier": "non-relative"
+}

--- a/api/.vscode/settings.json
+++ b/api/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "typescript.preferences.importModuleSpecifier": "non-relative"
-}

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -2,9 +2,7 @@
   "include": ["src/**/*.ts", "test/**/*.test.ts"],
   "compilerOptions": {
     "target": "ES2022",
-    "lib": [
-      "ES2022"
-    ],
+    "lib": ["ES2022"],
     "module": "commonjs",
     "allowJs": true,
     "outDir": "build",
@@ -18,9 +16,9 @@
     "sourceMap": true,
     "resolveJsonModule": true,
     "paths": {
-      "@root/*": ["./*"],
+      "@controller/*": ["src/controller/*"],
       "@src/*": ["src/*"],
-      "@controller/*": ["src/controller/*"]
+      "@root/*": ["./*"]
     }
   }
 }


### PR DESCRIPTION
Resolves #26 

# Changes

- Add `vscode` workspace folder setting
    - `importModuleSpecfier`: `non-relative` (Prefers a non-relative import based on the baseUrl or paths configured in jsconfig.json / tsconfig.json.)