### PR TITLE
[#75] Add api returning server time

### DIFF
--- a/api/generate/openapi.json
+++ b/api/generate/openapi.json
@@ -58,6 +58,43 @@
         }
       }
     },
+    "/api/v1/dev/server-time": {
+      "get": {
+        "operationId": "DevApiSpec_get_/server-time",
+        "tags": [
+          "Development"
+        ],
+        "summary": "Server Time",
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServerTimeV1Response"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/healthz/liveness": {
       "get": {
         "operationId": "HealthApiSpec_get_/liveness",
@@ -125,6 +162,18 @@
           }
         },
         "additionalProperties": false
+      },
+      "ServerTimeV1Response": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "message"
+        ]
       },
       "LivenessResponse": {
         "type": "object",

--- a/api/src/controller/http/dev/dev.v1.controller.ts
+++ b/api/src/controller/http/dev/dev.v1.controller.ts
@@ -1,7 +1,10 @@
 import { Request, Response, Router } from 'express';
 
 import { GreetingV1Request } from '@controller/http/dev/request/dev.v1.request';
-import { GreetingV1Response } from '@controller/http/dev/response/dev.v1.response';
+import {
+  GreetingV1Response,
+  ServerTimeV1Response
+} from '@controller/http/dev/response/dev.v1.response';
 import { methodNotAllowed } from '@controller/http/handler';
 
 export class DevV1Controller {
@@ -14,6 +17,11 @@ export class DevV1Controller {
       .post(this.greeting)
       .all(methodNotAllowed);
 
+    router
+      .route(`${prefix}/server-time`)
+      .get(this.serverTime)
+      .all(methodNotAllowed);
+
     return router;
   };
 
@@ -22,5 +30,14 @@ export class DevV1Controller {
     res: Response<GreetingV1Response>
   ) => {
     res.send({ message: 'Hello World!' });
+  };
+
+  public serverTime = async (
+    req: Request,
+    res: Response<ServerTimeV1Response>
+  ) => {
+    const now = new Date();
+
+    res.send({ message: now.toISOString() });
   };
 }

--- a/api/src/controller/http/dev/response/dev.v1.response.ts
+++ b/api/src/controller/http/dev/response/dev.v1.response.ts
@@ -1,3 +1,7 @@
 export interface GreetingV1Response {
   message?: string;
 }
+
+export interface ServerTimeV1Response {
+  message: string;
+}

--- a/api/src/controller/http/dev/schema/dev.v1.schema.ts
+++ b/api/src/controller/http/dev/schema/dev.v1.schema.ts
@@ -1,7 +1,10 @@
 import { Tspec } from 'tspec';
 
 import { GreetingV1Request } from '@controller/http/dev/request/dev.v1.request';
-import { GreetingV1Response } from '@controller/http/dev/response/dev.v1.response';
+import {
+  GreetingV1Response,
+  ServerTimeV1Response
+} from '@controller/http/dev/response/dev.v1.response';
 import { HttpErrorResponse } from '@controller/http/response';
 
 export type DevApiSpec = Tspec.DefineApiSpec<{
@@ -15,6 +18,15 @@ export type DevApiSpec = Tspec.DefineApiSpec<{
         body: GreetingV1Request;
         responses: {
           200: GreetingV1Response;
+          default: HttpErrorResponse;
+        };
+      };
+    };
+    '/server-time': {
+      get: {
+        summary: 'Server Time';
+        responses: {
+          200: ServerTimeV1Response;
           default: HttpErrorResponse;
         };
       };


### PR DESCRIPTION
Resolves #75 

# Changes

- UI 에서 HTTP 요청/응답 동작을 확인하는 용도로 사용할 엔드포인트를 API에 추가합니다. (`api/v1/dev/server-time`)
- 서버 시간을 반환합니다.