### PR TITLE
[#84] Enhance Flexibility in CustomError

### DIFF
--- a/api/src/controller/http/handler.ts
+++ b/api/src/controller/http/handler.ts
@@ -10,11 +10,10 @@ export const methodNotAllowed = (
   res: Response<HttpErrorResponse>,
   next: NextFunction
 ) => {
-  const error = new CustomError(
-    HttpErrorCode.METHOD_NOT_ALLOWED,
-    new Error('Method not allowed'),
-    `The ${req.method} for the "${req.originalUrl}" route is not allowed`
-  );
+  const error = new CustomError({
+    code: HttpErrorCode.METHOD_NOT_ALLOWED,
+    message: `The ${req.method} for the "${req.originalUrl}" route is not allowed`
+  });
   res.locals.error = error;
   res.status(405).send({
     messages: error.messages

--- a/api/src/controller/http/middleware.ts
+++ b/api/src/controller/http/middleware.ts
@@ -44,11 +44,11 @@ export class Middleware {
     } else if (err instanceof ValidationError) {
       customError = this.convertValidationErrorToCustomError(err);
     } else {
-      customError = new CustomError(
-        HttpErrorCode.INTERNAL_ERROR,
-        err,
-        'Unexpected error occured'
-      );
+      customError = new CustomError({
+        code: HttpErrorCode.INTERNAL_ERROR,
+        cause: err,
+        message: 'Unexpected error occured'
+      });
     }
 
     this.responseError(customError, res);
@@ -61,11 +61,11 @@ export class Middleware {
     next: NextFunction
   ) => {
     this.responseError(
-      new CustomError(
-        HttpErrorCode.NOT_FOUND,
-        new Error('Not found route'),
-        'No matching route found'
-      ),
+      new CustomError({
+        code: HttpErrorCode.NOT_FOUND,
+        cause: new Error('Not found route'),
+        messages: ['No matching route found']
+      }),
       res
     );
   };
@@ -77,43 +77,59 @@ export class Middleware {
 
     switch (err.status) {
       case 400:
-        return new CustomError(HttpErrorCode.BAD_REQUEST, err, ...errMessages);
+        return new CustomError({
+          code: HttpErrorCode.BAD_REQUEST,
+          cause: err,
+          messages: errMessages
+        });
       case 401:
-        return new CustomError(HttpErrorCode.UNAUTHORIZED, err, ...errMessages);
+        return new CustomError({
+          code: HttpErrorCode.UNAUTHORIZED,
+          cause: err,
+          messages: errMessages
+        });
       case 403:
-        return new CustomError(HttpErrorCode.FORBIDDEN, err, ...errMessages);
+        return new CustomError({
+          code: HttpErrorCode.FORBIDDEN,
+          cause: err,
+          messages: errMessages
+        });
       case 404:
-        return new CustomError(HttpErrorCode.NOT_FOUND, err, ...errMessages);
+        return new CustomError({
+          code: HttpErrorCode.NOT_FOUND,
+          cause: err,
+          messages: errMessages
+        });
       case 405:
-        return new CustomError(
-          HttpErrorCode.METHOD_NOT_ALLOWED,
-          err,
-          ...errMessages
-        );
+        return new CustomError({
+          code: HttpErrorCode.METHOD_NOT_ALLOWED,
+          cause: err,
+          messages: errMessages
+        });
       case 406:
-        return new CustomError(
-          HttpErrorCode.NOT_ACCEPTABLE,
-          err,
-          ...errMessages
-        );
+        return new CustomError({
+          code: HttpErrorCode.NOT_ACCEPTABLE,
+          cause: err,
+          messages: errMessages
+        });
       case 413:
-        return new CustomError(
-          HttpErrorCode.PAYLOAD_TOO_LARGE,
-          err,
-          ...errMessages
-        );
+        return new CustomError({
+          code: HttpErrorCode.PAYLOAD_TOO_LARGE,
+          cause: err,
+          messages: errMessages
+        });
       case 415:
-        return new CustomError(
-          HttpErrorCode.UNSUPPORTED_MEDIA_TYPE,
-          err,
-          ...errMessages
-        );
+        return new CustomError({
+          code: HttpErrorCode.UNSUPPORTED_MEDIA_TYPE,
+          cause: err,
+          messages: errMessages
+        });
       default:
-        return new CustomError(
-          HttpErrorCode.INTERNAL_ERROR,
-          err,
-          ...errMessages
-        );
+        return new CustomError({
+          code: HttpErrorCode.INTERNAL_ERROR,
+          cause: err,
+          messages: errMessages
+        });
     }
   };
 

--- a/api/src/error/errors.ts
+++ b/api/src/error/errors.ts
@@ -19,16 +19,36 @@ export enum HttpErrorCode {
   INTERNAL_ERROR
 }
 
-export class CustomError extends Error {
-  messages: string[];
+interface CustomErrorBuilder {
+  code: AppErrorCode | HttpErrorCode;
+  cause?: unknown;
+  message?: string;
+  messages?: string[];
+  context?: Record<string, any>;
+}
 
-  constructor(
-    public code: AppErrorCode | HttpErrorCode,
-    public origin: unknown,
-    ...messages: string[]
-  ) {
+export class CustomError extends Error {
+  public readonly code: AppErrorCode | HttpErrorCode;
+  public readonly cause?: unknown;
+  public readonly messages: string[];
+  public readonly context?: Record<string, any>;
+
+  constructor(builder: CustomErrorBuilder) {
+    let messages;
+
+    if (builder.message) {
+      messages = [builder.message];
+    } else if (builder.messages) {
+      messages = builder.messages;
+    } else {
+      messages = ['Custom Error'];
+    }
+
     super(messages[0]);
+    this.code = builder.code;
+    this.cause = builder.cause;
     this.messages = messages;
+    this.context = builder.context;
   }
 
   public getHttpStatusCode = () => {

--- a/api/src/util/error.ts
+++ b/api/src/util/error.ts
@@ -7,7 +7,7 @@ export function isErrorWithMessage(error: unknown): error is ErrorWithMessage {
     typeof error === 'object' &&
     error !== null &&
     'message' in error &&
-    typeof (error as Record<string, unknown>).message === 'string'
+    typeof error.message === 'string'
   );
 }
 

--- a/api/test/controller/http/middleware.test.ts
+++ b/api/test/controller/http/middleware.test.ts
@@ -137,19 +137,19 @@ class TestController {
   }
 
   public throwSyncCustomError = (req: Request, res: Response) => {
-    throw new CustomError(
-      HttpErrorCode.INTERNAL_ERROR,
-      new Error('Internal error'),
-      'Error from throwSyncCustomError'
-    );
+    throw new CustomError({
+      code: HttpErrorCode.INTERNAL_ERROR,
+      cause: new Error('Internal error'),
+      message: 'Error from throwSyncCustomError'
+    });
   };
 
   public throwAsyncCustomError = async (req: Request, res: Response) => {
-    throw new CustomError(
-      HttpErrorCode.INTERNAL_ERROR,
-      new Error('Internal error'),
-      'Error from throwAsyncCustomError'
-    );
+    throw new CustomError({
+      code: HttpErrorCode.INTERNAL_ERROR,
+      cause: new Error('Internal error'),
+      message: 'Error from throwAsyncCustomError'
+    });
   };
 
   public throwSyncError = (req: Request, res: Response) => {


### PR DESCRIPTION
Resolves #84

# Changes

- Refactor `CustomError`:
  - Rename `origin` to `cause` [ref](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Error/cause)
  - Make `cause` optional for enhanced flexibility
  - Introduce `context` to capture error context
  - Initialize with `CustomPayload`
- Optimize error utility function