### PR TITLE
[#85] Fix empty object output for Error objects

### DIFF
--- a/api/src/logger/logger.ts
+++ b/api/src/logger/logger.ts
@@ -10,46 +10,6 @@ import {
 import { CustomError } from '@src/error/errors';
 import { LogFormat, LoggerConfig } from '@src/logger/types';
 
-function convertErrorToObject(target: TransformableInfo) {
-  const nestedErrorKeys = [];
-  for (const [nestedKey, nestedValue] of Object.entries(target)) {
-    if (nestedValue instanceof Error) {
-      nestedErrorKeys.push(nestedKey);
-    }
-  }
-
-  for (const nestedKey of nestedErrorKeys) {
-    target[nestedKey] = Object.assign(
-      {
-        message: target[nestedKey].message,
-        stack: target[nestedKey].stack
-      },
-      target[nestedKey]
-    );
-  }
-
-  if (target instanceof CustomError) {
-    // Object.assign() performs a deep copy for primitive types with depth 0
-    target = Object.assign(
-      {
-        stack: target.stack
-      },
-      target
-    );
-    return target;
-  } else {
-    // Object.assign() performs a deep copy for primitive types with depth 0
-    target = Object.assign(
-      {
-        message: target.message,
-        stack: target.stack
-      },
-      target
-    );
-    return target;
-  }
-}
-
 function convertErrorPropertiesToObject(target: TransformableInfo) {
   const errorKeys = [];
   for (const [key, value] of Object.entries(target)) {
@@ -93,12 +53,6 @@ function convertErrorPropertiesToObject(target: TransformableInfo) {
 }
 
 const enumerateErrorFormat = format((info) => {
-  // info
-  if (info instanceof Error) {
-    return convertErrorToObject(info);
-  }
-
-  // metadata
   convertErrorPropertiesToObject(info);
   return info;
 });


### PR DESCRIPTION
Resolves #85

# Changes

- Implement a function to convert error properties into plain objects.

#  Example Scenario
```typescript
// Error log
logger.error('error log', { error: new Error('test') });

// CustomError log
logger.error('custom error log', {
error: new CustomError({
  code: AppErrorCode.INTERNAL_ERROR,
  cause: new Error('cause'),
  messages: ['custom error message'],
  context: { foo: 'bar' }
})
});
```

# BEFORE

## TEXT
```bash
# Error log
[2023-12-19 23:02:44][error]: error log
{
  "deployment": "dev",
  "error": {}
}

# CustomError log
[2023-12-19 23:02:45][error]: custom error log
{
  "deployment": "dev",
  "error": {
    "code": 5,
    "cause": {},
    "messages": [
      "custom error message"
    ],
    "context": {
      "foo": "bar"
    }
  }
}
```

## JSON
```jsonc
// Error log
{
  "deployment": "dev",
  "error": {},
  "level": "error",
  "message": "error log",
  "timestamp": "2023-12-19 23:06:39"
}

// CustomError log
{
  "deployment": "dev",
  "error": {
    "cause": {},
    "code": 5,
    "context": {
      "foo": "bar"
    },
    "messages": [
      "custom error message"
    ]
  },
  "level": "error",
  "message": "custom error log",
  "timestamp": "2023-12-19 23:06:39"
}
```


# AFTER

## TEXT
```bash
# Error log
[2023-12-19 23:10:07][error]: error log
{
  "deployment": "dev",
  "error": {
    "message": "test",
    "stack": "Error: test\n    at main (/Users/gimseong-won/coding/Mr.C/api/src/main.ts:47:38)\n    at Object.<anonymous> (/Users/gimseong-won/coding/Mr.C/api/src/main.ts:103:3)\n    at Module._compile (node:internal/modules/cjs/loader:1254:14)\n    at Module.m._compile (/Users/gimseong-won/coding/Mr.C/api/node_modules/ts-node/src/index.ts:1618:23)\n    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)\n    at Object.require.extensions.<computed> [as .ts] (/Users/gimseong-won/coding/Mr.C/api/node_modules/ts-node/src/index.ts:1621:12)\n    at Module.load (node:internal/modules/cjs/loader:1117:32)\n    at Function.Module._load (node:internal/modules/cjs/loader:958:12)\n    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)\n    at phase4 (/Users/gimseong-won/coding/Mr.C/api/node_modules/ts-node/src/bin.ts:649:14)"
  }
}

# CustomError log
[2023-12-19 23:10:07][error]: custom error log
{
  "deployment": "dev",
  "error": {
    "stack": "Error: custom error message\n    at main (/Users/gimseong-won/coding/Mr.C/api/src/main.ts:49:12)\n    at Object.<anonymous> (/Users/gimseong-won/coding/Mr.C/api/src/main.ts:103:3)\n    at Module._compile (node:internal/modules/cjs/loader:1254:14)\n    at Module.m._compile (/Users/gimseong-won/coding/Mr.C/api/node_modules/ts-node/src/index.ts:1618:23)\n    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)\n    at Object.require.extensions.<computed> [as .ts] (/Users/gimseong-won/coding/Mr.C/api/node_modules/ts-node/src/index.ts:1621:12)\n    at Module.load (node:internal/modules/cjs/loader:1117:32)\n    at Function.Module._load (node:internal/modules/cjs/loader:958:12)\n    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)\n    at phase4 (/Users/gimseong-won/coding/Mr.C/api/node_modules/ts-node/src/bin.ts:649:14)",
    "code": 5,
    "cause": {
      "message": "cause",
      "stack": "Error: cause\n    at main (/Users/gimseong-won/coding/Mr.C/api/src/main.ts:51:14)\n    at Object.<anonymous> (/Users/gimseong-won/coding/Mr.C/api/src/main.ts:103:3)\n    at Module._compile (node:internal/modules/cjs/loader:1254:14)\n    at Module.m._compile (/Users/gimseong-won/coding/Mr.C/api/node_modules/ts-node/src/index.ts:1618:23)\n    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)\n    at Object.require.extensions.<computed> [as .ts] (/Users/gimseong-won/coding/Mr.C/api/node_modules/ts-node/src/index.ts:1621:12)\n    at Module.load (node:internal/modules/cjs/loader:1117:32)\n    at Function.Module._load (node:internal/modules/cjs/loader:958:12)\n    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)\n    at phase4 (/Users/gimseong-won/coding/Mr.C/api/node_modules/ts-node/src/bin.ts:649:14)"
    },
    "messages": [
      "custom error message"
    ],
    "context": {
      "foo": "bar"
    }
  }
}
```

## JSON
```jsonc
// Error log
{
  "deployment": "dev",
  "error": {
    "message": "test",
    "stack": "Error: test\n    at main (/Users/gimseong-won/coding/Mr.C/api/src/main.ts:47:38)\n    at Object.<anonymous> (/Users/gimseong-won/coding/Mr.C/api/src/main.ts:103:3)\n    at Module._compile (node:internal/modules/cjs/loader:1254:14)\n    at Module.m._compile (/Users/gimseong-won/coding/Mr.C/api/node_modules/ts-node/src/index.ts:1618:23)\n    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)\n    at Object.require.extensions.<computed> [as .ts] (/Users/gimseong-won/coding/Mr.C/api/node_modules/ts-node/src/index.ts:1621:12)\n    at Module.load (node:internal/modules/cjs/loader:1117:32)\n    at Function.Module._load (node:internal/modules/cjs/loader:958:12)\n    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)\n    at phase4 (/Users/gimseong-won/coding/Mr.C/api/node_modules/ts-node/src/bin.ts:649:14)"
  },
  "level": "error",
  "message": "error log",
  "timestamp": "2023-12-19 23:11:59"
}

// CustomError log
{
  "deployment": "dev",
  "error": {
    "cause": {
      "message": "cause",
      "stack": "Error: cause\n    at main (/Users/gimseong-won/coding/Mr.C/api/src/main.ts:51:14)\n    at Object.<anonymous> (/Users/gimseong-won/coding/Mr.C/api/src/main.ts:103:3)\n    at Module._compile (node:internal/modules/cjs/loader:1254:14)\n    at Module.m._compile (/Users/gimseong-won/coding/Mr.C/api/node_modules/ts-node/src/index.ts:1618:23)\n    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)\n    at Object.require.extensions.<computed> [as .ts] (/Users/gimseong-won/coding/Mr.C/api/node_modules/ts-node/src/index.ts:1621:12)\n    at Module.load (node:internal/modules/cjs/loader:1117:32)\n    at Function.Module._load (node:internal/modules/cjs/loader:958:12)\n    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)\n    at phase4 (/Users/gimseong-won/coding/Mr.C/api/node_modules/ts-node/src/bin.ts:649:14)"
    },
    "code": 5,
    "context": {
      "foo": "bar"
    },
    "messages": [
      "custom error message"
    ],
    "stack": "Error: custom error message\n    at main (/Users/gimseong-won/coding/Mr.C/api/src/main.ts:49:12)\n    at Object.<anonymous> (/Users/gimseong-won/coding/Mr.C/api/src/main.ts:103:3)\n    at Module._compile (node:internal/modules/cjs/loader:1254:14)\n    at Module.m._compile (/Users/gimseong-won/coding/Mr.C/api/node_modules/ts-node/src/index.ts:1618:23)\n    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)\n    at Object.require.extensions.<computed> [as .ts] (/Users/gimseong-won/coding/Mr.C/api/node_modules/ts-node/src/index.ts:1621:12)\n    at Module.load (node:internal/modules/cjs/loader:1117:32)\n    at Function.Module._load (node:internal/modules/cjs/loader:958:12)\n    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)\n    at phase4 (/Users/gimseong-won/coding/Mr.C/api/node_modules/ts-node/src/bin.ts:649:14)"
  },
  "level": "error",
  "message": "custom error log",
  "timestamp": "2023-12-19 23:11:59"
}
```