### PR TITLE
[#88] Revise OAuth function signatures

### DIFF
--- a/api/src/config/loader.ts
+++ b/api/src/config/loader.ts
@@ -81,7 +81,7 @@ export function buildGoogleClientConfig(config: Config): GoogleClientConfig {
     oauth: {
       clientId: config.google.oauth.clientId,
       clientSecret: config.google.oauth.clientSecret,
-      redirectUri: `${config.http.host}:${config.http.port}${config.google.oauth.redirectPath}`,
+      redirectPath: config.google.oauth.redirectPath,
       authEndpoint: config.google.endpoints.auth,
       tokenEndpoint: config.google.endpoints.token
     }

--- a/api/src/core/ports/google.handler.ts
+++ b/api/src/core/ports/google.handler.ts
@@ -1,3 +1,3 @@
 export interface GoogleHandler {
-  buildOidcRequest(protocol: string, state: string): string;
+  buildOidcRequest(baseUrl: string, state: string): string;
 }

--- a/api/src/core/services/auth/auth.service.ts
+++ b/api/src/core/services/auth/auth.service.ts
@@ -11,17 +11,17 @@ export class AuthService {
     private readonly googleHandler: GoogleHandler
   ) {}
 
-  public initiateGoogleSignIn = (
-    protocol: string,
+  public initiateGoogleSignIn = async (
+    baseUrl: string,
     referrer: string | null
-  ): string => {
+  ): Promise<string> => {
     const state = randomUUID();
     const stateTokenString = JSON.stringify({ state, referrer });
-    this.keyValueRepository.set(
+    await this.keyValueRepository.set(
       state,
       stateTokenString,
       this.config.oauthStateExpirationMinutes * 60
     );
-    return this.googleHandler.buildOidcRequest(protocol, state);
+    return this.googleHandler.buildOidcRequest(baseUrl, state);
   };
 }

--- a/api/src/infrastructure/google/google.client.ts
+++ b/api/src/infrastructure/google/google.client.ts
@@ -7,12 +7,12 @@ import { GoogleClientConfig } from '@src/infrastructure/google/types';
 export class GoogleClient implements GoogleHandler {
   constructor(private readonly config: GoogleClientConfig) {}
 
-  public buildOidcRequest(protocol: string, state: string): string {
+  public buildOidcRequest = (baseUrl: string, state: string): string => {
     const queryString = stringify({
       client_id: this.config.oauth.clientId,
       nonce: randomUUID(),
       response_type: 'code',
-      redirect_uri: `${protocol}://${this.config.oauth.redirectUri}`,
+      redirect_uri: `${baseUrl}${this.config.oauth.redirectPath}`,
       scope: 'openid email',
       state: state,
       access_type: 'online',
@@ -20,5 +20,5 @@ export class GoogleClient implements GoogleHandler {
     });
 
     return `${this.config.oauth.authEndpoint}?${queryString}`;
-  }
+  };
 }

--- a/api/src/infrastructure/google/types.ts
+++ b/api/src/infrastructure/google/types.ts
@@ -5,7 +5,7 @@ export interface GoogleClientConfig {
 interface GoogleOauthConfig {
   clientId: string;
   clientSecret: string;
-  redirectUri: string;
+  redirectPath: string;
   authEndpoint: string;
   tokenEndpoint: string;
 }

--- a/api/test/config/loader.test.ts
+++ b/api/test/config/loader.test.ts
@@ -140,7 +140,7 @@ describe('Test build google client config', () => {
       oauth: {
         clientId: 'test_client_id',
         clientSecret: 'test_client_secret',
-        redirectUri: '127.0.0.1:0/api/v1/google/sign-in/token',
+        redirectPath: '/api/v1/google/sign-in/token',
         authEndpoint: 'https://accounts.google.com/o/oauth2/auth',
         tokenEndpoint: 'https://oauth2.googleapis.com/token'
       }

--- a/api/test/core/services/auth/auth.service.test.ts
+++ b/api/test/core/services/auth/auth.service.test.ts
@@ -10,8 +10,9 @@ jest.mock('crypto');
 
 describe('Test auth service', () => {
   const oauthClientId = 'test_client_id';
-  const oauthRedirectUri = '127.0.0.1:0/api/v1/google/sign-in/token';
+  const oauthRedirectPath = '/api/v1/google/sign-in/token';
   const oauthAuthEndpoint = 'https://accounts.google.com/o/oauth2/auth';
+  const host = 'localhost:8080';
   const nonce = '2fc312e4-0c04-4f93-b0bf-c9e81f244814';
   const state = '8a5c8a05-0a20-49f9-92a5-a6f83d5617e9';
   const response_type = 'code';
@@ -19,6 +20,7 @@ describe('Test auth service', () => {
   const scope = 'openid email';
   const access_type = 'online';
   const prompt = 'consent select_account';
+  const baseUrl = `${protocol}://${host}`;
   const authConfig: AuthConfig = { oauthStateExpirationMinutes: 10 };
   let keyValueRepository: KeyValueRepository;
   let googleHandler: GoogleHandler;
@@ -32,32 +34,32 @@ describe('Test auth service', () => {
     googleHandler = {
       buildOidcRequest: jest.fn(() => {
         return encodeURI(
-          `${oauthAuthEndpoint}?client_id=${oauthClientId}&nonce=${nonce}&response_type=${response_type}&redirect_uri=${protocol}://${oauthRedirectUri}&scope=${scope}&state=${state}&access_type=${access_type}&prompt=${prompt}`
+          `${oauthAuthEndpoint}?client_id=${oauthClientId}&nonce=${nonce}&response_type=${response_type}&redirect_uri=${baseUrl}${oauthRedirectPath}&scope=${scope}&state=${state}&access_type=${access_type}&prompt=${prompt}`
         );
       })
     };
     jest.spyOn(crypto, 'randomUUID').mockReturnValue(state);
+  });
+
+  it('should success initiate Google sign in and return valid OIDC request', async () => {
     authService = new AuthService(
       authConfig,
       keyValueRepository,
       googleHandler
     );
-  });
-
-  it('should return valid OIDC request', () => {
     const givenReferrer = 'http://127.0.0.1/home';
     const expectedQueyObject = {
       client_id: oauthClientId,
       response_type,
-      redirect_uri: `${protocol}://${oauthRedirectUri}`,
+      redirect_uri: `${baseUrl}${oauthRedirectPath}`,
       state,
       scope,
       access_type,
       prompt
     };
 
-    const redirectUrl = authService.initiateGoogleSignIn(
-      protocol,
+    const redirectUrl = await authService.initiateGoogleSignIn(
+      baseUrl,
       givenReferrer
     );
     const [authEndpoint, queryString] = redirectUrl.split('?');
@@ -79,6 +81,6 @@ describe('Test auth service', () => {
     );
 
     expect(googleHandler.buildOidcRequest).toBeCalledTimes(1);
-    expect(googleHandler.buildOidcRequest).toBeCalledWith(protocol, state);
+    expect(googleHandler.buildOidcRequest).toBeCalledWith(baseUrl, state);
   });
 });

--- a/api/test/infrastructure/google/google.client.test.ts
+++ b/api/test/infrastructure/google/google.client.test.ts
@@ -13,7 +13,7 @@ describe('Test google client', () => {
       oauth: {
         clientId: 'test_client_id',
         clientSecret: 'test_client_secret',
-        redirectUri: '127.0.0.1:0/api/v1/google/sign-in/token',
+        redirectPath: '/api/v1/google/sign-in/token',
         authEndpoint: 'https://accounts.google.com/o/oauth2/auth',
         tokenEndpoint: 'https://oauth2.googleapis.com/token'
       }
@@ -21,20 +21,24 @@ describe('Test google client', () => {
     client = new GoogleClient(config);
   });
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should build valid OIDC request', () => {
-    const givenProtocol = 'http';
+    const givenBaseUrl = 'http://localhost:8080';
     const givenState = randomUUID();
     const expectedQueyObject = {
       client_id: config.oauth.clientId,
       response_type: 'code',
-      redirect_uri: `${givenProtocol}://${config.oauth.redirectUri}`,
+      redirect_uri: `${givenBaseUrl}${config.oauth.redirectPath}`,
       scope: 'openid email',
       state: givenState,
       access_type: 'online',
       prompt: 'consent select_account'
     };
 
-    const result = client.buildOidcRequest(givenProtocol, givenState);
+    const result = client.buildOidcRequest(givenBaseUrl, givenState);
     const [authEndpoint, queryString] = result.split('?');
 
     expect(authEndpoint).toEqual(config.oauth.authEndpoint);


### PR DESCRIPTION
#88 #100

# Changes

- Rename the configuration value from `redirectUri` to `redirectPath`.
- Update function signatures:
  - Change `initiateGoogleSignIn` from a synchronous function to an asynchronous function.
  - Replace the `protocol` parameter with a mandatory `baseUrl` parameter in the `initiateGoogleSignIn` function.
  - Replace the `protocol` parameter with a mandatory `baseUrl` parameter in the `buildOidcRequest` function.