### PR TITLE
[#112] Add methods to enum

### DIFF
--- a/api/src/component/component.handler.ts
+++ b/api/src/component/component.handler.ts
@@ -1,4 +1,3 @@
-import { PrismaClient } from '@prisma/client';
 import { Logger } from 'winston';
 
 import {
@@ -16,6 +15,7 @@ import { AuthService } from '@src/core/services/auth/auth.service';
 import { GoogleClient } from '@src/infrastructure/google/google.client';
 import { generatePrismaClient } from '@src/infrastructure/prisma/prisma.client';
 import { PrismaTransactionManager } from '@src/infrastructure/prisma/prisma.transaction.manager';
+import { ExtendedPrismaClient } from '@src/infrastructure/prisma/types';
 import {
   RedisClient,
   generateRedisClient
@@ -30,7 +30,7 @@ import { HttpServer } from '@controller/http/server';
 export class ComponentHandler {
   private config!: Config;
   private logger!: Logger;
-  private prismaClient!: PrismaClient;
+  private prismaClient!: ExtendedPrismaClient;
   private redisClient!: RedisClient;
   private httpServer!: HttpServer;
   private readonly shutdownSignals = ['SIGINT', 'SIGTERM'];

--- a/api/src/core/auth.manager.ts
+++ b/api/src/core/auth.manager.ts
@@ -1,9 +1,8 @@
-import { AccessLevel } from '@prisma/client';
-
 import { AppIdToken } from '@src/core/entities/auth.entity';
+import { AccessLevelEnum } from '@src/core/types';
 
 export function validateUserAuthorization(
-  requiredLevel: AccessLevel,
+  requiredLevel: AccessLevelEnum,
   requesterIdToken: AppIdToken,
   requestedUserId: string
 ): boolean {
@@ -17,25 +16,11 @@ export function validateUserAuthorization(
 }
 
 export function validateAccessLevel(
-  requiredLevel: AccessLevel,
-  userLevel: AccessLevel
+  requiredLevel: AccessLevelEnum,
+  userLevel: AccessLevelEnum
 ): boolean {
-  const requiredLevelNumber = convertAccessLevelToNumber(requiredLevel);
-  const userLevelNumber = convertAccessLevelToNumber(userLevel);
-
-  if (userLevelNumber < requiredLevelNumber) {
+  if (userLevel.toNumber() < requiredLevel.toNumber()) {
     return false;
   }
   return true;
-}
-
-function convertAccessLevelToNumber(accessLevel: AccessLevel): number {
-  switch (accessLevel) {
-    case AccessLevel.USER:
-      return 1;
-    case AccessLevel.DEVELOPER:
-      return 2;
-    case AccessLevel.ADMIN:
-      return 3;
-  }
 }

--- a/api/src/core/entities/auth.entity.ts
+++ b/api/src/core/entities/auth.entity.ts
@@ -1,19 +1,19 @@
-import { AccessLevel, Idp } from '@prisma/client';
+import { AccessLevelEnum, IdpEnum } from '@src/core/types';
 
 export interface AppIdToken {
   userId: string;
   nickname: string;
   tag: string;
-  idp: Idp;
+  idp: IdpEnum;
   email: string;
-  accessLevel: AccessLevel;
+  accessLevel: AccessLevelEnum;
 }
 
 export interface GoogleIdToken {
   iss: string;
   aud: string;
   sub: string;
-  idp: Idp;
   email: string;
-  accessLevel: AccessLevel;
+  iat: number;
+  exp: number;
 }

--- a/api/src/core/entities/user.entity.ts
+++ b/api/src/core/entities/user.entity.ts
@@ -1,12 +1,12 @@
-import { AccessLevel, Idp } from '@prisma/client';
+import { AccessLevelEnum, IdpEnum } from '@src/core/types';
 
 export interface User {
   id: string;
   nickname: string;
   tag: string;
-  idp: Idp;
+  idp: IdpEnum;
   email: string;
-  accessLevel: AccessLevel;
+  accessLevel: AccessLevelEnum;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/api/src/core/services/auth/auth.service.ts
+++ b/api/src/core/services/auth/auth.service.ts
@@ -15,6 +15,7 @@ import {
 } from '@src/core/ports/transaction.manager';
 import { UserRepository } from '@src/core/ports/user.repository';
 import { AuthConfig, OauthState } from '@src/core/services/auth/types';
+import { AccessLevelEnum, IdpEnum } from '@src/core/types';
 import { validateGoogleIdToken } from '@src/core/validator';
 import { AppErrorCode, CustomError } from '@src/error/errors';
 import { IsolationLevel } from '@src/infrastructure/repositories/types';
@@ -109,9 +110,9 @@ export class AuthService {
               id: userId,
               nickname: userNickname,
               tag: userTag,
-              idp: Idp.GOOGLE,
+              idp: new IdpEnum(Idp.GOOGLE),
               email: payload.email,
-              accessLevel: AccessLevel.USER,
+              accessLevel: new AccessLevelEnum(AccessLevel.USER),
               createdAt: currentDate,
               updatedAt: currentDate
             };

--- a/api/src/core/types.ts
+++ b/api/src/core/types.ts
@@ -1,0 +1,28 @@
+import { AccessLevel, Idp } from '@prisma/client';
+
+export class IdpEnum {
+  constructor(private readonly idp: Idp) {}
+
+  public get = (): Idp => {
+    return this.idp;
+  };
+}
+
+export class AccessLevelEnum {
+  constructor(private readonly accessLevel: AccessLevel) {}
+
+  public get = (): AccessLevel => {
+    return this.accessLevel;
+  };
+
+  public toNumber = (): number => {
+    switch (this.accessLevel) {
+      case AccessLevel.USER:
+        return 1;
+      case AccessLevel.DEVELOPER:
+        return 2;
+      case AccessLevel.ADMIN:
+        return 3;
+    }
+  };
+}

--- a/api/src/infrastructure/prisma/prisma.client.ts
+++ b/api/src/infrastructure/prisma/prisma.client.ts
@@ -1,12 +1,12 @@
 import { PrismaClient } from '@prisma/client';
+import { User as UserModel } from '@prisma/client';
 import { Logger } from 'winston';
 
+import { User } from '@src/core/entities/user.entity';
+import { AccessLevelEnum, IdpEnum } from '@src/core/types';
 import { DatabaseConfig } from '@src/infrastructure/repositories/types';
 
-export function generatePrismaClient(
-  logger: Logger,
-  config: DatabaseConfig
-): PrismaClient {
+export function generatePrismaClient(logger: Logger, config: DatabaseConfig) {
   const prismaClient = new PrismaClient({
     datasources: {
       db: {
@@ -19,5 +19,38 @@ export function generatePrismaClient(
     logger.info('Shutdown prisma client');
   });
 
-  return prismaClient;
+  const extendedPrismaClient = prismaClient.$extends({
+    result: {
+      user: {
+        convertToEntity: {
+          needs: {
+            id: true,
+            nickname: true,
+            tag: true,
+            idp: true,
+            email: true,
+            accessLevel: true,
+            createdAt: true,
+            updatedAt: true
+          },
+          compute(user: UserModel) {
+            return (): User => {
+              return {
+                id: user.id,
+                nickname: user.nickname,
+                tag: user.tag,
+                idp: new IdpEnum(user.idp),
+                email: user.email,
+                accessLevel: new AccessLevelEnum(user.accessLevel),
+                createdAt: user.createdAt,
+                updatedAt: user.updatedAt
+              };
+            };
+          }
+        }
+      }
+    }
+  });
+
+  return extendedPrismaClient;
 }

--- a/api/src/infrastructure/prisma/prisma.transaction.manager.ts
+++ b/api/src/infrastructure/prisma/prisma.transaction.manager.ts
@@ -1,17 +1,19 @@
-import { Prisma, PrismaClient } from '@prisma/client';
-
 import { TransactionManager } from '@src/core/ports/transaction.manager';
 import {
   PrismaErrorCode,
   isErrorWithCode
 } from '@src/infrastructure/prisma/errors';
+import {
+  ExtendedPrismaClient,
+  ExtendedPrismaTransactionClient
+} from '@src/infrastructure/prisma/types';
 import { IsolationLevel } from '@src/infrastructure/repositories/types';
 
 export class PrismaTransactionManager implements TransactionManager {
-  constructor(private readonly client: PrismaClient) {}
+  constructor(private readonly client: ExtendedPrismaClient) {}
 
   public runInTransaction = async <T>(
-    callback: (tx: Prisma.TransactionClient) => Promise<T>,
+    callback: (tx: ExtendedPrismaTransactionClient) => Promise<T>,
     isolationLevel: IsolationLevel,
     maxRetries = 3
   ): Promise<T | null> => {

--- a/api/src/infrastructure/prisma/types.ts
+++ b/api/src/infrastructure/prisma/types.ts
@@ -1,0 +1,10 @@
+import { ITXClientDenyList } from '@prisma/client/runtime/library';
+
+import { generatePrismaClient } from '@src/infrastructure/prisma/prisma.client';
+
+export type ExtendedPrismaClient = ReturnType<typeof generatePrismaClient>;
+
+export type ExtendedPrismaTransactionClient = Omit<
+  ExtendedPrismaClient,
+  ITXClientDenyList
+>;

--- a/api/src/jwt/payload.ts
+++ b/api/src/jwt/payload.ts
@@ -1,6 +1,7 @@
 import { AccessLevel, Idp } from '@prisma/client';
 
 import { AppIdToken } from '@src/core/entities/auth.entity';
+import { AccessLevelEnum, IdpEnum } from '@src/core/types';
 import { isStringEnumValue } from '@src/util/guard';
 
 export const mrcIssuer = 'movie-reivew-comment';
@@ -33,9 +34,9 @@ export function createAppPayload(
     userId: appIdToken.userId,
     nickname: appIdToken.nickname,
     tag: appIdToken.tag,
-    idp: appIdToken.idp,
+    idp: appIdToken.idp.get(),
     email: appIdToken.email,
-    accessLevel: appIdToken.accessLevel
+    accessLevel: appIdToken.accessLevel.get()
   };
 }
 
@@ -44,9 +45,9 @@ export function convertToAppIdToken(appPayload: AppPayload): AppIdToken {
     userId: appPayload.userId,
     nickname: appPayload.nickname,
     tag: appPayload.tag,
-    idp: appPayload.idp,
+    idp: new IdpEnum(appPayload.idp),
     email: appPayload.email,
-    accessLevel: appPayload.accessLevel
+    accessLevel: new AccessLevelEnum(appPayload.accessLevel)
   };
 }
 

--- a/api/test/core/auth.manager.test.ts
+++ b/api/test/core/auth.manager.test.ts
@@ -2,16 +2,17 @@ import { AccessLevel } from '@prisma/client';
 
 import { validateUserAuthorization } from '@src/core/auth.manager';
 import { AppIdToken } from '@src/core/entities/auth.entity';
+import { AccessLevelEnum } from '@src/core/types';
 
 describe('Test validate user authorization', () => {
   const requestedUserId = 'randomId';
   const requesterUserId = 'anotherRandomId';
 
   it('should return true when given access level is high enough', () => {
-    const givenRequiredLevel = AccessLevel.ADMIN;
+    const givenRequiredLevel = new AccessLevelEnum(AccessLevel.ADMIN);
     const givenRequesterIdToken = {
       userId: requesterUserId,
-      accessLevel: AccessLevel.ADMIN
+      accessLevel: new AccessLevelEnum(AccessLevel.ADMIN)
     } as AppIdToken;
 
     expect(
@@ -24,10 +25,10 @@ describe('Test validate user authorization', () => {
   });
 
   it('should return true when the requester ID is equal to the requested ID', () => {
-    const givenRequiredAccessLevel = AccessLevel.ADMIN;
+    const givenRequiredAccessLevel = new AccessLevelEnum(AccessLevel.ADMIN);
     const givenRequesterIdToken = {
       userId: requestedUserId,
-      accessLevel: AccessLevel.USER
+      accessLevel: new AccessLevelEnum(AccessLevel.USER)
     } as AppIdToken;
 
     expect(
@@ -40,10 +41,10 @@ describe('Test validate user authorization', () => {
   });
 
   it("should return false when requester's access level is not sufficient", () => {
-    const givenRequiredAccessLevel = AccessLevel.ADMIN;
+    const givenRequiredAccessLevel = new AccessLevelEnum(AccessLevel.ADMIN);
     const givenRequesterIdToken = {
       userId: requesterUserId,
-      accessLevel: AccessLevel.USER
+      accessLevel: new AccessLevelEnum(AccessLevel.USER)
     } as AppIdToken;
 
     expect(

--- a/api/test/core/services/auth/auth.service.test.ts
+++ b/api/test/core/services/auth/auth.service.test.ts
@@ -11,6 +11,7 @@ import { UserRepository } from '@src/core/ports/user.repository';
 import { AuthService } from '@src/core/services/auth/auth.service';
 import { AuthConfig } from '@src/core/services/auth/types';
 import { AppErrorCode, CustomError } from '@src/error/errors';
+import { AccessLevelEnum, IdpEnum } from '@src/core/types';
 
 jest.mock('crypto');
 
@@ -140,9 +141,9 @@ describe('Test auth service', () => {
         id: '57cf27d8-0c74-4963-94a7-47c35741ed06',
         nickname: '도전적인 평론가 연두빛 하마',
         tag: '#AZ7J',
-        idp: Idp.GOOGLE,
+        idp: new IdpEnum(Idp.GOOGLE),
         email: givenEmail,
-        accessLevel: AccessLevel.USER,
+        accessLevel: new AccessLevelEnum(AccessLevel.USER),
         createdAt: currentDate,
         updatedAt: currentDate
       };


### PR DESCRIPTION
#112 

# Changes

- Add methods to enum
  - IdpEnum
    - get
  - AccessLevelEnum
    - get
    - toNumber
- Add `convertToEntity` method to Prisma user result
- Define and apply extended Prisma client types
  - ExtendedPrismaClient
  - ExtendedPrismaTransactionClient