### PR TITLE
[#112] Implement update user service method

### DIFF
--- a/api/src/core/ports/transaction.manager.ts
+++ b/api/src/core/ports/transaction.manager.ts
@@ -7,5 +7,5 @@ export interface TransactionManager {
     callback: (tx: TransactionClient) => Promise<T>,
     isolationLevel: IsolationLevel,
     maxRetries?: number
-  ): Promise<T | null>;
+  ): Promise<T>;
 }

--- a/api/src/core/services/auth/auth.service.ts
+++ b/api/src/core/services/auth/auth.service.ts
@@ -76,7 +76,7 @@ export class AuthService {
       });
     }
 
-    const user = (await this.txManager.runInTransaction(
+    const user = await this.txManager.runInTransaction(
       async (txClient: TransactionClient): Promise<User> => {
         let userFound: User | null;
         let userId: string;
@@ -123,7 +123,7 @@ export class AuthService {
         }
       },
       IsolationLevel.READ_COMMITTED
-    )) as User;
+    );
 
     const appIdToken = this.jwtHandler.signAppIdToken(
       new AppIdToken(

--- a/api/src/core/services/user/user.service.ts
+++ b/api/src/core/services/user/user.service.ts
@@ -2,12 +2,20 @@ import { AccessLevel } from '@prisma/client';
 
 import { AppIdToken } from '@src/core/entities/auth.entity';
 import { User } from '@src/core/entities/user.entity';
+import {
+  TransactionClient,
+  TransactionManager
+} from '@src/core/ports/transaction.manager';
 import { UserRepository } from '@src/core/ports/user.repository';
 import { AccessLevelEnum } from '@src/core/types';
 import { AppErrorCode, CustomError } from '@src/error/errors';
+import { IsolationLevel } from '@src/infrastructure/repositories/types';
 
 export class UserService {
-  constructor(private readonly userRepository: UserRepository) {}
+  constructor(
+    private readonly userRepository: UserRepository,
+    private readonly txManager: TransactionManager
+  ) {}
 
   public getUser = async (
     requesterIdToken: AppIdToken,
@@ -27,5 +35,36 @@ export class UserService {
     }
 
     return await this.userRepository.findById(requestedUserId);
+  };
+
+  public updateUser = async (
+    requesterIdToken: AppIdToken,
+    requestedUserId: string,
+    requestedAccessLevel: AccessLevel
+  ): Promise<User> => {
+    if (
+      !requesterIdToken.isAccessLevelAuthorized(
+        new AccessLevelEnum(AccessLevel.ADMIN)
+      )
+    ) {
+      throw new CustomError({
+        code: AppErrorCode.PERMISSIION_DENIED,
+        message: 'insufficient access level to update user',
+        context: { accessLevel: requesterIdToken.accessLevel }
+      });
+    }
+
+    return (await this.txManager.runInTransaction(
+      async (txClient: TransactionClient): Promise<User> => {
+        const userFound = await this.userRepository.findById(
+          requestedUserId,
+          txClient
+        );
+        userFound.accessLevel = new AccessLevelEnum(requestedAccessLevel);
+
+        return await this.userRepository.upsert(userFound, txClient);
+      },
+      IsolationLevel.READ_COMMITTED
+    )) as User;
   };
 }

--- a/api/src/core/services/user/user.service.ts
+++ b/api/src/core/services/user/user.service.ts
@@ -54,7 +54,7 @@ export class UserService {
       });
     }
 
-    return (await this.txManager.runInTransaction(
+    return await this.txManager.runInTransaction(
       async (txClient: TransactionClient): Promise<User> => {
         const userFound = await this.userRepository.findById(
           requestedUserId,
@@ -65,6 +65,6 @@ export class UserService {
         return await this.userRepository.upsert(userFound, txClient);
       },
       IsolationLevel.READ_COMMITTED
-    )) as User;
+    );
   };
 }

--- a/api/src/infrastructure/prisma/prisma.transaction.manager.ts
+++ b/api/src/infrastructure/prisma/prisma.transaction.manager.ts
@@ -1,4 +1,5 @@
 import { TransactionManager } from '@src/core/ports/transaction.manager';
+import { AppErrorCode, CustomError } from '@src/error/errors';
 import {
   PrismaErrorCode,
   isErrorWithCode
@@ -16,9 +17,9 @@ export class PrismaTransactionManager implements TransactionManager {
     callback: (tx: ExtendedPrismaTransactionClient) => Promise<T>,
     isolationLevel: IsolationLevel,
     maxRetries = 3
-  ): Promise<T | null> => {
+  ): Promise<T> => {
     let retries = 0;
-    let result: T | null = null;
+    let result: T | undefined = undefined;
 
     while (retries < maxRetries) {
       try {
@@ -37,6 +38,14 @@ export class PrismaTransactionManager implements TransactionManager {
 
         throw error;
       }
+    }
+
+    if (result === undefined) {
+      throw new CustomError({
+        code: AppErrorCode.INTERNAL_ERROR,
+        message: 'failed to transaction',
+        context: { callback, isolationLevel }
+      });
     }
 
     return result;

--- a/api/test/core/services/user/user.service.test.ts
+++ b/api/test/core/services/user/user.service.test.ts
@@ -2,6 +2,7 @@ import { AccessLevel, Idp } from '@prisma/client';
 
 import { AppIdToken } from '@src/core/entities/auth.entity';
 import { User } from '@src/core/entities/user.entity';
+import { TransactionManager } from '@src/core/ports/transaction.manager';
 import { UserRepository } from '@src/core/ports/user.repository';
 import { UserService } from '@src/core/services/user/user.service';
 import { AccessLevelEnum, IdpEnum } from '@src/core/types';
@@ -22,6 +23,7 @@ describe('Test user service', () => {
     updatedAt: currentDate
   };
   let userRepository: UserRepository;
+  let txManager: TransactionManager;
 
   beforeAll(() => {
     userRepository = {
@@ -29,6 +31,9 @@ describe('Test user service', () => {
       findByEmail: jest.fn(),
       upsert: jest.fn(),
       deleteById: jest.fn()
+    };
+    txManager = {
+      runInTransaction: jest.fn()
     };
   });
 
@@ -50,10 +55,10 @@ describe('Test user service', () => {
         'user1@gmail.com',
         new AccessLevelEnum(AccessLevel.DEVELOPER)
       );
-      const actualResult = await new UserService(userRepository).getUser(
-        givenRequesterIdToken,
-        requestedUserId
-      );
+      const actualResult = await new UserService(
+        userRepository,
+        txManager
+      ).getUser(givenRequesterIdToken, requestedUserId);
 
       expect(actualResult).toStrictEqual(user);
 
@@ -71,7 +76,7 @@ describe('Test user service', () => {
           'user1@gmail.com',
           new AccessLevelEnum(AccessLevel.USER)
         );
-        await new UserService(userRepository).getUser(
+        await new UserService(userRepository, txManager).getUser(
           givenRequesterIdToken,
           requestedUserId
         );
@@ -81,6 +86,71 @@ describe('Test user service', () => {
       }
 
       expect(userRepository.findById).toBeCalledTimes(0);
+    });
+  });
+
+  describe('Test update user', () => {
+    const givenRequesterIdToken = new AppIdToken(
+      requesterUserId,
+      'nickname',
+      '#TAGG',
+      new IdpEnum(Idp.GOOGLE),
+      'user1@gmail.com',
+      new AccessLevelEnum(AccessLevel.ADMIN)
+    );
+
+    const upsertedUser: User = {
+      id: user.id,
+      nickname: user.nickname,
+      tag: user.tag,
+      idp: user.idp,
+      email: user.email,
+      accessLevel: new AccessLevelEnum(AccessLevel.ADMIN),
+      createdAt: user.createdAt,
+      updatedAt: user.updatedAt
+    };
+    const requestedAccessLevel = AccessLevel.DEVELOPER;
+
+    beforeAll(() => {
+      txManager.runInTransaction<User> = jest.fn(() => Promise.resolve(upsertedUser))
+    });
+
+    it('should success when valid', async () => {
+      const actualResult = await new UserService(
+        userRepository,
+        txManager
+      ).updateUser(
+        givenRequesterIdToken,
+        requestedUserId,
+        requestedAccessLevel
+      );
+
+      expect(actualResult).toStrictEqual(upsertedUser);
+
+      expect(txManager.runInTransaction).toBeCalledTimes(1);
+    });
+
+    it("should failure when requester's access level is not sufficient", async () => {
+      try {
+        const givenRequesterIdToken = new AppIdToken(
+          requesterUserId,
+          'nickname',
+          '#TAGG',
+          new IdpEnum(Idp.GOOGLE),
+          'user1@gmail.com',
+          new AccessLevelEnum(AccessLevel.USER)
+        );
+        await new UserService(userRepository, txManager).updateUser(
+          givenRequesterIdToken,
+          requestedUserId,
+          requestedAccessLevel
+        );
+      } catch (error: unknown) {
+        expect(error).toBeInstanceOf(CustomError);
+        expect(error).toHaveProperty('code', AppErrorCode.PERMISSIION_DENIED);
+      }
+
+      expect(txManager.runInTransaction).toBeCalledTimes(0);
     });
   });
 });


### PR DESCRIPTION
#112

# Changes

- Implement Update User Service Method:
  - Add the implementation for the "update user" service method
- Update Transaction Manager:
  - Enhance type handling for cases when all transaction attempts fail
  - Refine the `runInTransaction` method signature to incorporate improvements in type handling scenarios