### PR TITLE
[#120] Set default font

### DIFF
--- a/ui/packages/mr-c.app/src/app/layout.tsx
+++ b/ui/packages/mr-c.app/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next';
 import '@/styles/globals.css';
+import { notoSansKr } from '@/fonts';
 
 export const metadata: Metadata = {
   title: 'Home',
@@ -15,7 +16,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body className={`${notoSansKr.className} antialiased`}>{children}</body>
     </html>
   );
 }

--- a/ui/packages/mr-c.app/src/fonts/index.ts
+++ b/ui/packages/mr-c.app/src/fonts/index.ts
@@ -1,0 +1,16 @@
+import { Noto_Sans_KR as NotoSansKr } from 'next/font/google';
+
+// next/font fetches the font files on build time
+// i.e. '.next/static/media/**.woff2'
+// but supports preloading only for the subsets.
+// Not preloaded font files are loaded on browser later
+// than html.
+export const notoSansKr = NotoSansKr({
+  // 'korean' subset is not supported
+  subsets: ['latin'],
+  // While loading, we don't show the text with
+  // fallback font til 3s at most (FOIT)
+  // instead of showing ugly font changing (FOUT).
+  display: 'block',
+  adjustFontFallback: true,
+});


### PR DESCRIPTION
Resolves #120 

# Changes

- default font 로 [Noto Sans Korean](https://fonts.google.com/noto/specimen/Noto+Sans+KR) 를 설정합니다. (참고: [우리는 왜 웹 환경에서 Noto Sans를 사용하는가?](https://s-core.co.kr/insight/view/%EC%9A%B0%EB%A6%AC%EB%8A%94-%EC%99%9C-%EC%9B%B9-%ED%99%98%EA%B2%BD%EC%97%90%EC%84%9C-noto-sans%EB%A5%BC-%EC%82%AC%EC%9A%A9%ED%95%98%EB%8A%94%EA%B0%80/))
- `next/font` 는 빌드타임에 폰트 파일을 페칭합니다.
- subset 에 한하여 브라우져에 `preload` 되는데 `next/font` 는 현재 'korean' subset을 지원하지 않습니다.
- 따라서 한글 폰트파일이 로드되는 동안 브라우져에서 FOIT, FOUT 가 발생합니다.

https://github.com/MovieReviewComment/Mr.C/assets/40269597/db301484-ca48-4339-8acd-c2a6d5ec8cd6

![foit-vs-fout](https://github.com/MovieReviewComment/Mr.C/assets/40269597/0d5b87c1-376f-4a6a-b455-4ac3daa44cf0)


- `display: 'block'` 으로 한글 폰트 파일이 브라우져에 로드되는 동안 해당 텍스트를 렌더링하지 않습니다. (`FOIT`)
- 이는 일부 브라우져(i.e. chrome)의 기본 동작이며, 모든 유저 환경에서 일관된 ui 를 위해 명시적으로 설정합니다.
- 크롬과 파이어폭스에서는 최대 3초가 지나면 `display: block` 인 경우에도 fallback 폰트를 렌더링하게 됩니다.
- 이때 폰트간 사이즈 차이로 인한 레이아웃 쉬프팅을 방지하기 위하여 `adjustFontFallback` 옵션을 사용합니다. (아래 스크린샷 참조)
<img width="972" alt="image" src="https://github.com/MovieReviewComment/Mr.C/assets/40269597/4d281285-5cb0-4642-84c8-bdbd2d38d63d">

<img width="1600" alt="image" src="https://github.com/MovieReviewComment/Mr.C/assets/40269597/c990d687-ad58-4452-b71b-c32eab86bc22">
