### PR TITLE
[#124] Add packages for tailwindcss usablity

### DIFF
--- a/ui/.prettierrc
+++ b/ui/.prettierrc
@@ -3,5 +3,7 @@
   "semi": true,
   "trailingComma": "es5",
   "singleQuote": true,
-  "printWidth": 100
+  "printWidth": 100,
+  "plugins": ["prettier-plugin-tailwindcss"],
+  "tailwindFunctions": ["clsx"]
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "husky": "^8.0.0",
     "lint-staged": "^14.0.1",
-    "prettier": "^3.0.3"
+    "prettier": "^3.0.3",
+    "prettier-plugin-tailwindcss": "^0.5.11"
   }
 }

--- a/ui/packages/mr-c.app/package.json
+++ b/ui/packages/mr-c.app/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@mrc/common-components": "workspace:*",
     "@mrc/common-utils": "workspace:*",
+    "clsx": "^2.1.0",
     "next": "^14.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2290,6 +2290,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^6.7.3
     "@typescript-eslint/parser": ^6.7.3
     autoprefixer: ^10.4.16
+    clsx: ^2.1.0
     eslint: ^8.51.0
     eslint-config-next: ^13.5.5
     jest: ^29.7.0
@@ -6295,6 +6296,13 @@ __metadata:
   version: 1.0.4
   resolution: "clone@npm:1.0.4"
   checksum: d06418b7335897209e77bdd430d04f882189582e67bd1f75a04565f3f07f5b3f119a9d670c943b6697d0afb100f03b866b3b8a1f91d4d02d72c4ecf2bb64b5dd
+  languageName: node
+  linkType: hard
+
+"clsx@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "clsx@npm:2.1.0"
+  checksum: 43fefc29b6b49c9476fbce4f8b1cc75c27b67747738e598e6651dd40d63692135dc60b18fa1c5b78a2a9ba8ae6fd2055a068924b94e20b42039bd53b78b98e1d
   languageName: node
   linkType: hard
 
@@ -10867,6 +10875,7 @@ __metadata:
     husky: ^8.0.0
     lint-staged: ^14.0.1
     prettier: ^3.0.3
+    prettier-plugin-tailwindcss: ^0.5.11
   languageName: unknown
   linkType: soft
 
@@ -11794,6 +11803,57 @@ __metadata:
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"
   checksum: cd192ec0d0a8e4c6da3bb80e4f62afe336df3f76271ac6deb0e6a36187133b6073a19e9727a1ff108cd8b9982e4768850d413baa71214dd80c7979617dca827a
+  languageName: node
+  linkType: hard
+
+"prettier-plugin-tailwindcss@npm:^0.5.11":
+  version: 0.5.11
+  resolution: "prettier-plugin-tailwindcss@npm:0.5.11"
+  peerDependencies:
+    "@ianvs/prettier-plugin-sort-imports": "*"
+    "@prettier/plugin-pug": "*"
+    "@shopify/prettier-plugin-liquid": "*"
+    "@trivago/prettier-plugin-sort-imports": "*"
+    prettier: ^3.0
+    prettier-plugin-astro: "*"
+    prettier-plugin-css-order: "*"
+    prettier-plugin-import-sort: "*"
+    prettier-plugin-jsdoc: "*"
+    prettier-plugin-marko: "*"
+    prettier-plugin-organize-attributes: "*"
+    prettier-plugin-organize-imports: "*"
+    prettier-plugin-style-order: "*"
+    prettier-plugin-svelte: "*"
+  peerDependenciesMeta:
+    "@ianvs/prettier-plugin-sort-imports":
+      optional: true
+    "@prettier/plugin-pug":
+      optional: true
+    "@shopify/prettier-plugin-liquid":
+      optional: true
+    "@trivago/prettier-plugin-sort-imports":
+      optional: true
+    prettier-plugin-astro:
+      optional: true
+    prettier-plugin-css-order:
+      optional: true
+    prettier-plugin-import-sort:
+      optional: true
+    prettier-plugin-jsdoc:
+      optional: true
+    prettier-plugin-marko:
+      optional: true
+    prettier-plugin-organize-attributes:
+      optional: true
+    prettier-plugin-organize-imports:
+      optional: true
+    prettier-plugin-style-order:
+      optional: true
+    prettier-plugin-svelte:
+      optional: true
+    prettier-plugin-twig-melody:
+      optional: true
+  checksum: 450646db10dbcec76fe6be7bfc85e2e3c6bd1a6c9026637fc9c7f9a0882d8adf6b6fb589be6d24e6a4868772d44b55278a3a39760aa9feee2cf281db9215c0f6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves #124

# Changes

- tailwindcss 의 사용성을 위한 패키지 추가입니다.
- 태그의 className 어트리뷰트 외부에서도 clsx 함수의 인자에 대하여 정렬을 수행합니다.
- 예시 (참고: [sorting-classes-in-function-calls](https://github.com/tailwindlabs/prettier-plugin-tailwindcss?tab=readme-ov-file#sorting-classes-in-function-calls)):
    ```ts
    import clsx from 'clsx'

    function MyButton({ isHovering, children }) {
      const classes = clsx(
        'rounded bg-blue-500 px-4 py-2 text-base text-white',
        {
          'bg-blue-700 text-gray-100': isHovering,
        },
      )

      return (
        <button className={classes}>
          {children}
        </button>
      )
    }
    ```