### PR TITLE
[#144] Introduce Prisma mocking

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -50,6 +50,7 @@
                 "@typescript-eslint/parser": "^5.58.0",
                 "eslint": "^8.38.0",
                 "jest": "^29.5.0",
+                "jest-mock-extended": "^3.0.5",
                 "nodemon": "^2.0.22",
                 "prettier": "^2.8.7",
                 "supertest": "^6.3.3",
@@ -5493,6 +5494,19 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/jest-mock-extended": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/jest-mock-extended/-/jest-mock-extended-3.0.5.tgz",
+            "integrity": "sha512-/eHdaNPUAXe7f65gHH5urc8SbRVWjYxBqmCgax2uqOBJy8UUcCBMN1upj1eZ8y/i+IqpyEm4Kq0VKss/GCCTdw==",
+            "dev": true,
+            "dependencies": {
+                "ts-essentials": "^7.0.3"
+            },
+            "peerDependencies": {
+                "jest": "^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0",
+                "typescript": "^3.0.0 || ^4.0.0 || ^5.0.0"
+            }
+        },
         "node_modules/jest-pnp-resolver": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
@@ -7728,6 +7742,15 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
             "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
+        },
+        "node_modules/ts-essentials": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.3.tgz",
+            "integrity": "sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==",
+            "dev": true,
+            "peerDependencies": {
+                "typescript": ">=3.7.0"
+            }
         },
         "node_modules/ts-jest": {
             "version": "29.1.1",

--- a/api/package.json
+++ b/api/package.json
@@ -45,6 +45,7 @@
         "@typescript-eslint/parser": "^5.58.0",
         "eslint": "^8.38.0",
         "jest": "^29.5.0",
+        "jest-mock-extended": "^3.0.5",
         "nodemon": "^2.0.22",
         "prettier": "^2.8.7",
         "supertest": "^6.3.3",

--- a/api/test/infrastructure/prisma/test.prisma.client.ts
+++ b/api/test/infrastructure/prisma/test.prisma.client.ts
@@ -1,0 +1,7 @@
+import { PrismaClient } from '@prisma/client';
+
+import { extension } from '@src/infrastructure/prisma/prisma.client';
+
+const extendedPrisma = new PrismaClient().$extends(extension);
+
+export default extendedPrisma;


### PR DESCRIPTION
Resolve #144

# Changes
- Introduce `jest-mock-extended` package to facilitate mocking of Prisma client.
- Declare a test Prisma client.
- Refactor transaction tests:
    - Enhance Auth service test:
        - Clearly define test cases for user creation and user found.
    - Improve User service test