### PR TITLE
[#163] Introduce WYSIWYG editor

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -11,8 +11,10 @@
       "license": "MIT",
       "dependencies": {
         "@heroicons/react": "^2.1.1",
+        "@lexical/react": "^0.13.1",
         "clsx": "^2.1.0",
         "dayjs": "^1.11.10",
+        "lexical": "^0.13.1",
         "next": "^14.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -2283,7 +2285,6 @@
       "version": "7.23.9",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
       "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -3558,6 +3559,243 @@
       "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
       "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
       "dev": true
+    },
+    "node_modules/@lexical/clipboard": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.13.1.tgz",
+      "integrity": "sha512-gMSbVeqb7S+XAi/EMMlwl+FCurLPugN2jAXcp5k5ZaUd7be8B+iupbYdoKkjt4qBhxmvmfe9k46GoC0QOPl/nw==",
+      "dependencies": {
+        "@lexical/html": "0.13.1",
+        "@lexical/list": "0.13.1",
+        "@lexical/selection": "0.13.1",
+        "@lexical/utils": "0.13.1"
+      },
+      "peerDependencies": {
+        "lexical": "0.13.1"
+      }
+    },
+    "node_modules/@lexical/code": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.13.1.tgz",
+      "integrity": "sha512-QK77r3QgEtJy96ahYXNgpve8EY64BQgBSnPDOuqVrLdl92nPzjqzlsko2OZldlrt7gjXcfl9nqfhZ/CAhStfOg==",
+      "dependencies": {
+        "@lexical/utils": "0.13.1",
+        "prismjs": "^1.27.0"
+      },
+      "peerDependencies": {
+        "lexical": "0.13.1"
+      }
+    },
+    "node_modules/@lexical/dragon": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.13.1.tgz",
+      "integrity": "sha512-aNlqfif4//jW7gOxbBgdrbDovU6m3EwQrUw+Y/vqRkY+sWmloyAUeNwCPH1QP3Q5cvfolzOeN5igfBljsFr+1g==",
+      "peerDependencies": {
+        "lexical": "0.13.1"
+      }
+    },
+    "node_modules/@lexical/hashtag": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.13.1.tgz",
+      "integrity": "sha512-Dl0dUG4ZXNjYYuAUR0GMGpLGsA+cps2/ln3xEmy28bZR0sKkjXugsu2QOIxZjYIPBewDrXzPcvK8md45cMYoSg==",
+      "dependencies": {
+        "@lexical/utils": "0.13.1"
+      },
+      "peerDependencies": {
+        "lexical": "0.13.1"
+      }
+    },
+    "node_modules/@lexical/history": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.13.1.tgz",
+      "integrity": "sha512-cZXt30MalEEiRaflE9tHeGYnwT1xSDjXLsf9M409DSU9POJyZ1fsULJrG1tWv2uFQOhwal33rve9+MatUlITrg==",
+      "dependencies": {
+        "@lexical/utils": "0.13.1"
+      },
+      "peerDependencies": {
+        "lexical": "0.13.1"
+      }
+    },
+    "node_modules/@lexical/html": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.13.1.tgz",
+      "integrity": "sha512-XkZrnCSHIUavtpMol6aG8YsJ5KqC9hMxEhAENf3HTGi3ocysCByyXOyt1EhEYpjJvgDG4wRqt25xGDbLjj1/sA==",
+      "dependencies": {
+        "@lexical/selection": "0.13.1",
+        "@lexical/utils": "0.13.1"
+      },
+      "peerDependencies": {
+        "lexical": "0.13.1"
+      }
+    },
+    "node_modules/@lexical/link": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.13.1.tgz",
+      "integrity": "sha512-7E3B2juL2UoMj2n+CiyFZ7tlpsdViAoIE7MpegXwfe/VQ66wFwk/VxGTa/69ng2EoF7E0kh+SldvGQDrWAWb1g==",
+      "dependencies": {
+        "@lexical/utils": "0.13.1"
+      },
+      "peerDependencies": {
+        "lexical": "0.13.1"
+      }
+    },
+    "node_modules/@lexical/list": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.13.1.tgz",
+      "integrity": "sha512-6U1pmNZcKLuOWiWRML8Raf9zSEuUCMlsOye82niyF6I0rpPgYo5UFghAAbGISDsyqzM1B2L4BgJ6XrCk/dJptg==",
+      "dependencies": {
+        "@lexical/utils": "0.13.1"
+      },
+      "peerDependencies": {
+        "lexical": "0.13.1"
+      }
+    },
+    "node_modules/@lexical/mark": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.13.1.tgz",
+      "integrity": "sha512-dW27PW8wWDOKFqXTBUuUfV+umU0KfwvXGkPUAxRJrvwUWk5RKaS48LhgbNlQ5BfT84Q8dSiQzvbaa6T40t9a3A==",
+      "dependencies": {
+        "@lexical/utils": "0.13.1"
+      },
+      "peerDependencies": {
+        "lexical": "0.13.1"
+      }
+    },
+    "node_modules/@lexical/markdown": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.13.1.tgz",
+      "integrity": "sha512-6tbdme2h5Zy/M88loVQVH5G0Nt7VMR9UUkyiSaicyBRDOU2OHacaXEp+KSS/XuF+d7TA+v/SzyDq8HS77cO1wA==",
+      "dependencies": {
+        "@lexical/code": "0.13.1",
+        "@lexical/link": "0.13.1",
+        "@lexical/list": "0.13.1",
+        "@lexical/rich-text": "0.13.1",
+        "@lexical/text": "0.13.1",
+        "@lexical/utils": "0.13.1"
+      },
+      "peerDependencies": {
+        "lexical": "0.13.1"
+      }
+    },
+    "node_modules/@lexical/offset": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.13.1.tgz",
+      "integrity": "sha512-j/RZcztJ7dyTrfA2+C3yXDzWDXV+XmMpD5BYeQCEApaHvlo20PHt1BISk7RcrnQW8PdzGvpKblRWf//c08LS9w==",
+      "peerDependencies": {
+        "lexical": "0.13.1"
+      }
+    },
+    "node_modules/@lexical/overflow": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.13.1.tgz",
+      "integrity": "sha512-Uw34j+qG2UJRCIR+bykfFMduFk7Pc4r/kNt8N1rjxGuGXAsreTVch1iOhu7Ev6tJgkURsduKuaJCAi7iHnKl7g==",
+      "peerDependencies": {
+        "lexical": "0.13.1"
+      }
+    },
+    "node_modules/@lexical/plain-text": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.13.1.tgz",
+      "integrity": "sha512-4j5KAsMKUvJ8LhVDSS4zczbYXzdfmgYSAVhmqpSnJtud425Nk0TAfpUBLFoivxZB7KMoT1LGWQZvd47IvJPvtA==",
+      "peerDependencies": {
+        "@lexical/clipboard": "0.13.1",
+        "@lexical/selection": "0.13.1",
+        "@lexical/utils": "0.13.1",
+        "lexical": "0.13.1"
+      }
+    },
+    "node_modules/@lexical/react": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.13.1.tgz",
+      "integrity": "sha512-Sy6EL230KAb0RZsZf1dZrRrc3+rvCDQWltcd8C/cqBUYlxsLYCW9s4f3RB2werngD/PtLYbBB48SYXNkIALITA==",
+      "dependencies": {
+        "@lexical/clipboard": "0.13.1",
+        "@lexical/code": "0.13.1",
+        "@lexical/dragon": "0.13.1",
+        "@lexical/hashtag": "0.13.1",
+        "@lexical/history": "0.13.1",
+        "@lexical/link": "0.13.1",
+        "@lexical/list": "0.13.1",
+        "@lexical/mark": "0.13.1",
+        "@lexical/markdown": "0.13.1",
+        "@lexical/overflow": "0.13.1",
+        "@lexical/plain-text": "0.13.1",
+        "@lexical/rich-text": "0.13.1",
+        "@lexical/selection": "0.13.1",
+        "@lexical/table": "0.13.1",
+        "@lexical/text": "0.13.1",
+        "@lexical/utils": "0.13.1",
+        "@lexical/yjs": "0.13.1",
+        "react-error-boundary": "^3.1.4"
+      },
+      "peerDependencies": {
+        "lexical": "0.13.1",
+        "react": ">=17.x",
+        "react-dom": ">=17.x"
+      }
+    },
+    "node_modules/@lexical/rich-text": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.13.1.tgz",
+      "integrity": "sha512-HliB9Ync06mv9DBg/5j0lIsTJp+exLHlaLJe+n8Zq1QNTzZzu2LsIT/Crquk50In7K/cjtlaQ/d5RB0LkjMHYg==",
+      "peerDependencies": {
+        "@lexical/clipboard": "0.13.1",
+        "@lexical/selection": "0.13.1",
+        "@lexical/utils": "0.13.1",
+        "lexical": "0.13.1"
+      }
+    },
+    "node_modules/@lexical/selection": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.13.1.tgz",
+      "integrity": "sha512-Kt9eSwjxPznj7yzIYipu9yYEgmRJhHiq3DNxHRxInYcZJWWNNHum2xKyxwwcN8QYBBzgfPegfM/geqQEJSV1lQ==",
+      "peerDependencies": {
+        "lexical": "0.13.1"
+      }
+    },
+    "node_modules/@lexical/table": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.13.1.tgz",
+      "integrity": "sha512-VQzgkfkEmnvn6C64O/kvl0HI3bFoBh3WA/U67ALw+DS11Mb5CKjbt0Gzm/258/reIxNMpshjjicpWMv9Miwauw==",
+      "dependencies": {
+        "@lexical/utils": "0.13.1"
+      },
+      "peerDependencies": {
+        "lexical": "0.13.1"
+      }
+    },
+    "node_modules/@lexical/text": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.13.1.tgz",
+      "integrity": "sha512-NYy3TZKt3qzReDwN2Rr5RxyFlg84JjXP2JQGMrXSSN7wYe73ysQIU6PqdVrz4iZkP+w34F3pl55dJ24ei3An9w==",
+      "peerDependencies": {
+        "lexical": "0.13.1"
+      }
+    },
+    "node_modules/@lexical/utils": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.13.1.tgz",
+      "integrity": "sha512-AtQQKzYymkbOaQxaBXjRBS8IPxF9zWQnqwHTUTrJqJ4hX71aIQd/thqZbfQETAFJfC8pNBZw5zpxN6yPHk23dQ==",
+      "dependencies": {
+        "@lexical/list": "0.13.1",
+        "@lexical/selection": "0.13.1",
+        "@lexical/table": "0.13.1"
+      },
+      "peerDependencies": {
+        "lexical": "0.13.1"
+      }
+    },
+    "node_modules/@lexical/yjs": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.13.1.tgz",
+      "integrity": "sha512-4GbqQM+PwNTV59AZoNrfTe/0rLjs+cX6Y6yAdZSRPBwr5L3JzYeU1TTcFCVQTtsE7KF8ddVP8sD7w9pi8rOWLA==",
+      "dependencies": {
+        "@lexical/offset": "0.13.1"
+      },
+      "peerDependencies": {
+        "lexical": "0.13.1",
+        "yjs": ">=13.5.22"
+      }
     },
     "node_modules/@mdx-js/react": {
       "version": "2.3.0",
@@ -14259,6 +14497,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "peer": true,
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -16116,6 +16364,31 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lexical": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.13.1.tgz",
+      "integrity": "sha512-jaqRYzVEfBKbX4FwYpd/g+MyOjRaraAel0iQsTrwvx3hyN0bswUZuzb6H6nGlFSjcdrc77wKpyKwoWj4aUd+Bw=="
+    },
+    "node_modules/lib0": {
+      "version": "0.2.88",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.88.tgz",
+      "integrity": "sha512-KyroiEvCeZcZEMx5Ys+b4u4eEBbA1ch7XUaBhYpwa/nPMrzTjUhI4RfcytmQfYoTBPcdyx+FX6WFNIoNuJzJfQ==",
+      "peer": true,
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/lilconfig": {
@@ -18945,6 +19218,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/prismjs": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
+      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -19447,6 +19728,21 @@
       "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
       "dev": true
     },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -19742,8 +20038,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
@@ -23288,6 +23583,23 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yjs": {
+      "version": "13.6.11",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.11.tgz",
+      "integrity": "sha512-FvRRJKX9u270dOLkllGF/UDCWwmIv2Z+ucM4v1QO1TuxdmoiMnSUXH1HAcOKOrkBEhQtPTkxep7tD2DrQB+l0g==",
+      "peer": true,
+      "dependencies": {
+        "lib0": "^0.2.86"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/yocto-queue": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -26,8 +26,10 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.1.1",
+    "@lexical/react": "^0.13.1",
     "clsx": "^2.1.0",
     "dayjs": "^1.11.10",
+    "lexical": "^0.13.1",
     "next": "^14.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/ui/src/components/editor/editor.stories.tsx
+++ b/ui/src/components/editor/editor.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { within, userEvent, expect } from '@storybook/test';
+
+import Editor from '@/components/editor';
+
+const meta = {
+  title: 'Review/Editor',
+  component: Editor,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Editor>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+
+  decorators: [
+    (Story) => (
+      <div className="w-80">
+        <Story />
+      </div>
+    ),
+  ],
+
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const element = canvas.getByTestId('content-editable');
+
+    await expect(element).toBeInTheDocument();
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    await userEvent.click(element);
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    await userEvent.type(element, 'hello world');
+  },
+};

--- a/ui/src/components/editor/index.tsx
+++ b/ui/src/components/editor/index.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { LexicalComposer, type InitialConfigType } from '@lexical/react/LexicalComposer';
+import { Plugins } from '@/components/editor/plugins';
+import nodes from '@/components/editor/nodes';
+import theme from '@/components/editor/theme';
+import '@/styles/editor.css';
+
+// This has to be rendered on client side only (no ssr!)
+export default function Editor() {
+  const initialConfig: InitialConfigType = {
+    nodes: [...nodes],
+    namespace: 'review-editor',
+    onError: (error: Error) => {
+      throw error;
+    },
+    theme: theme,
+  };
+
+  return (
+    <div className="editor">
+      <LexicalComposer initialConfig={initialConfig}>
+        <Plugins />
+      </LexicalComposer>
+    </div>
+  );
+}

--- a/ui/src/components/editor/nodes/index.tsx
+++ b/ui/src/components/editor/nodes/index.tsx
@@ -1,0 +1,15 @@
+import type { Klass, LexicalNode, LexicalNodeReplacement } from 'lexical';
+
+import { LinkNode } from '@lexical/link';
+import { ListNode, ListItemNode } from '@lexical/list';
+import { HeadingNode, QuoteNode } from '@lexical/rich-text';
+
+const mrcNodes: (Klass<LexicalNode> | LexicalNodeReplacement)[] = [
+  HeadingNode,
+  QuoteNode,
+  ListNode,
+  ListItemNode,
+  LinkNode,
+];
+
+export default mrcNodes;

--- a/ui/src/components/editor/plugins/index.tsx
+++ b/ui/src/components/editor/plugins/index.tsx
@@ -1,6 +1,7 @@
 import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin';
 import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary';
 import { ContentEditable } from '@lexical/react/LexicalContentEditable';
+import { MarkdownShortcutPlugin } from '@/components/editor/plugins/markdown-shorcut';
 
 function Placeholder() {
   return <div className="placeholder">Begin writing your review...</div>;
@@ -20,6 +21,7 @@ export function Plugins() {
         placeholder={<Placeholder />}
         ErrorBoundary={LexicalErrorBoundary}
       />
+      <MarkdownShortcutPlugin />
     </>
   );
 }

--- a/ui/src/components/editor/plugins/index.tsx
+++ b/ui/src/components/editor/plugins/index.tsx
@@ -1,0 +1,25 @@
+import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin';
+import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary';
+import { ContentEditable } from '@lexical/react/LexicalContentEditable';
+
+function Placeholder() {
+  return <div className="placeholder">Begin writing your review...</div>;
+}
+
+export function Plugins() {
+  return (
+    <>
+      <RichTextPlugin
+        contentEditable={
+          <div className="content-editable-wrapper">
+            <div className="content-editable">
+              <ContentEditable data-testid="content-editable" />
+            </div>
+          </div>
+        }
+        placeholder={<Placeholder />}
+        ErrorBoundary={LexicalErrorBoundary}
+      />
+    </>
+  );
+}

--- a/ui/src/components/editor/plugins/markdown-shorcut/index.tsx
+++ b/ui/src/components/editor/plugins/markdown-shorcut/index.tsx
@@ -1,0 +1,41 @@
+import { MarkdownShortcutPlugin as LexicalMarkdownShortcutPlugin } from '@lexical/react/LexicalMarkdownShortcutPlugin';
+import { TRANSFORMERS, CODE, INLINE_CODE, type Transformer } from '@lexical/markdown';
+
+const NO_USE = new Set<Transformer>([CODE, INLINE_CODE]);
+const TRANSFORMERS_IN_USE = TRANSFORMERS.filter((transformer) => !NO_USE.has(transformer));
+
+export function MarkdownShortcutPlugin() {
+  return <LexicalMarkdownShortcutPlugin transformers={TRANSFORMERS_IN_USE} />;
+}
+
+/*
+TRANSFORMERS from @lexical/markdown
+
+const TRANSFORMERS: Array<Transformer> = [
+  ...ELEMENT_TRANSFORMERS,
+  ...TEXT_FORMAT_TRANSFORMERS,
+  ...TEXT_MATCH_TRANSFORMERS,
+];
+
+const ELEMENT_TRANSFORMERS: Array<ElementTransformer> = [
+  HEADING,
+  QUOTE,
+  CODE,
+  UNORDERED_LIST,
+  ORDERED_LIST,
+];
+
+const TEXT_FORMAT_TRANSFORMERS: Array<TextFormatTransformer> = [
+  INLINE_CODE,
+  BOLD_ITALIC_STAR,
+  BOLD_ITALIC_UNDERSCORE,
+  BOLD_STAR,
+  BOLD_UNDERSCORE,
+  HIGHLIGHT,
+  ITALIC_STAR,
+  ITALIC_UNDERSCORE,
+  STRIKETHROUGH,
+];
+
+const TEXT_MATCH_TRANSFORMERS: Array<TextMatchTransformer> = [LINK];
+*/

--- a/ui/src/components/editor/theme/index.ts
+++ b/ui/src/components/editor/theme/index.ts
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type { EditorThemeClasses } from 'lexical';
+
+import '@/styles/editor-theme.css';
+
+const theme: EditorThemeClasses = {
+  blockCursor: 'PlaygroundEditorTheme__blockCursor',
+  characterLimit: 'PlaygroundEditorTheme__characterLimit',
+  code: 'PlaygroundEditorTheme__code',
+  codeHighlight: {
+    atrule: 'PlaygroundEditorTheme__tokenAttr',
+    attr: 'PlaygroundEditorTheme__tokenAttr',
+    boolean: 'PlaygroundEditorTheme__tokenProperty',
+    builtin: 'PlaygroundEditorTheme__tokenSelector',
+    cdata: 'PlaygroundEditorTheme__tokenComment',
+    char: 'PlaygroundEditorTheme__tokenSelector',
+    class: 'PlaygroundEditorTheme__tokenFunction',
+    'class-name': 'PlaygroundEditorTheme__tokenFunction',
+    comment: 'PlaygroundEditorTheme__tokenComment',
+    constant: 'PlaygroundEditorTheme__tokenProperty',
+    deleted: 'PlaygroundEditorTheme__tokenProperty',
+    doctype: 'PlaygroundEditorTheme__tokenComment',
+    entity: 'PlaygroundEditorTheme__tokenOperator',
+    function: 'PlaygroundEditorTheme__tokenFunction',
+    important: 'PlaygroundEditorTheme__tokenVariable',
+    inserted: 'PlaygroundEditorTheme__tokenSelector',
+    keyword: 'PlaygroundEditorTheme__tokenAttr',
+    namespace: 'PlaygroundEditorTheme__tokenVariable',
+    number: 'PlaygroundEditorTheme__tokenProperty',
+    operator: 'PlaygroundEditorTheme__tokenOperator',
+    prolog: 'PlaygroundEditorTheme__tokenComment',
+    property: 'PlaygroundEditorTheme__tokenProperty',
+    punctuation: 'PlaygroundEditorTheme__tokenPunctuation',
+    regex: 'PlaygroundEditorTheme__tokenVariable',
+    selector: 'PlaygroundEditorTheme__tokenSelector',
+    string: 'PlaygroundEditorTheme__tokenSelector',
+    symbol: 'PlaygroundEditorTheme__tokenProperty',
+    tag: 'PlaygroundEditorTheme__tokenProperty',
+    url: 'PlaygroundEditorTheme__tokenOperator',
+    variable: 'PlaygroundEditorTheme__tokenVariable',
+  },
+  embedBlock: {
+    base: 'PlaygroundEditorTheme__embedBlock',
+    focus: 'PlaygroundEditorTheme__embedBlockFocus',
+  },
+  hashtag: 'PlaygroundEditorTheme__hashtag',
+  heading: {
+    h1: 'PlaygroundEditorTheme__h1',
+    h2: 'PlaygroundEditorTheme__h2',
+    h3: 'PlaygroundEditorTheme__h3',
+    h4: 'PlaygroundEditorTheme__h4',
+    h5: 'PlaygroundEditorTheme__h5',
+    h6: 'PlaygroundEditorTheme__h6',
+  },
+  image: 'editor-image',
+  indent: 'PlaygroundEditorTheme__indent',
+  inlineImage: 'inline-editor-image',
+  layoutContainer: 'PlaygroundEditorTheme__layoutContainer',
+  layoutItem: 'PlaygroundEditorTheme__layoutItem',
+  link: 'PlaygroundEditorTheme__link',
+  list: {
+    checklist: 'PlaygroundEditorTheme__checklist',
+    listitem: 'PlaygroundEditorTheme__listItem',
+    listitemChecked: 'PlaygroundEditorTheme__listItemChecked',
+    listitemUnchecked: 'PlaygroundEditorTheme__listItemUnchecked',
+    nested: {
+      listitem: 'PlaygroundEditorTheme__nestedListItem',
+    },
+    olDepth: [
+      'PlaygroundEditorTheme__ol1',
+      'PlaygroundEditorTheme__ol2',
+      'PlaygroundEditorTheme__ol3',
+      'PlaygroundEditorTheme__ol4',
+      'PlaygroundEditorTheme__ol5',
+    ],
+    ul: 'PlaygroundEditorTheme__ul',
+  },
+  ltr: 'PlaygroundEditorTheme__ltr',
+  mark: 'PlaygroundEditorTheme__mark',
+  markOverlap: 'PlaygroundEditorTheme__markOverlap',
+  paragraph: 'PlaygroundEditorTheme__paragraph',
+  quote: 'PlaygroundEditorTheme__quote',
+  rtl: 'PlaygroundEditorTheme__rtl',
+  table: 'PlaygroundEditorTheme__table',
+  tableAddColumns: 'PlaygroundEditorTheme__tableAddColumns',
+  tableAddRows: 'PlaygroundEditorTheme__tableAddRows',
+  tableCell: 'PlaygroundEditorTheme__tableCell',
+  tableCellActionButton: 'PlaygroundEditorTheme__tableCellActionButton',
+  tableCellActionButtonContainer: 'PlaygroundEditorTheme__tableCellActionButtonContainer',
+  tableCellEditing: 'PlaygroundEditorTheme__tableCellEditing',
+  tableCellHeader: 'PlaygroundEditorTheme__tableCellHeader',
+  tableCellPrimarySelected: 'PlaygroundEditorTheme__tableCellPrimarySelected',
+  tableCellResizer: 'PlaygroundEditorTheme__tableCellResizer',
+  tableCellSelected: 'PlaygroundEditorTheme__tableCellSelected',
+  tableCellSortedIndicator: 'PlaygroundEditorTheme__tableCellSortedIndicator',
+  tableResizeRuler: 'PlaygroundEditorTheme__tableCellResizeRuler',
+  tableSelected: 'PlaygroundEditorTheme__tableSelected',
+  tableSelection: 'PlaygroundEditorTheme__tableSelection',
+  text: {
+    bold: 'PlaygroundEditorTheme__textBold',
+    code: 'PlaygroundEditorTheme__textCode',
+    italic: 'PlaygroundEditorTheme__textItalic',
+    strikethrough: 'PlaygroundEditorTheme__textStrikethrough',
+    subscript: 'PlaygroundEditorTheme__textSubscript',
+    superscript: 'PlaygroundEditorTheme__textSuperscript',
+    underline: 'PlaygroundEditorTheme__textUnderline',
+    underlineStrikethrough: 'PlaygroundEditorTheme__textUnderlineStrikethrough',
+  },
+};
+
+export default theme;

--- a/ui/src/styles/editor-theme.css
+++ b/ui/src/styles/editor-theme.css
@@ -1,0 +1,360 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+.PlaygroundEditorTheme__ltr {
+  text-align: left;
+}
+.PlaygroundEditorTheme__rtl {
+  text-align: right;
+}
+.PlaygroundEditorTheme__paragraph {
+  margin: 0;
+  position: relative;
+}
+.PlaygroundEditorTheme__quote {
+  margin: 0;
+  margin-left: 20px;
+  margin-bottom: 10px;
+  font-size: 15px;
+  color: rgb(101, 103, 107);
+  border-left-color: rgb(206, 208, 212);
+  border-left-width: 4px;
+  border-left-style: solid;
+  padding-left: 16px;
+}
+.PlaygroundEditorTheme__h1 {
+  font-size: 24px;
+  color: rgb(5, 5, 5);
+  font-weight: 400;
+  margin: 0;
+}
+.PlaygroundEditorTheme__h2 {
+  font-size: 15px;
+  color: rgb(101, 103, 107);
+  font-weight: 700;
+  margin: 0;
+  text-transform: uppercase;
+}
+.PlaygroundEditorTheme__h3 {
+  font-size: 12px;
+  margin: 0;
+  text-transform: uppercase;
+}
+.PlaygroundEditorTheme__indent {
+  --lexical-indent-base-value: 40px;
+}
+.PlaygroundEditorTheme__textBold {
+  font-weight: bold;
+}
+.PlaygroundEditorTheme__textItalic {
+  font-style: italic;
+}
+.PlaygroundEditorTheme__textUnderline {
+  text-decoration: underline;
+}
+.PlaygroundEditorTheme__textStrikethrough {
+  text-decoration: line-through;
+}
+.PlaygroundEditorTheme__textUnderlineStrikethrough {
+  text-decoration: underline line-through;
+}
+.PlaygroundEditorTheme__textSubscript {
+  font-size: 0.8em;
+  vertical-align: sub !important;
+}
+.PlaygroundEditorTheme__textSuperscript {
+  font-size: 0.8em;
+  vertical-align: super;
+}
+.PlaygroundEditorTheme__textCode {
+  background-color: rgb(240, 242, 245);
+  padding: 1px 0.25rem;
+  font-family: Menlo, Consolas, Monaco, monospace;
+  font-size: 94%;
+}
+.PlaygroundEditorTheme__hashtag {
+  background-color: rgba(88, 144, 255, 0.15);
+  border-bottom: 1px solid rgba(88, 144, 255, 0.3);
+}
+.PlaygroundEditorTheme__link {
+  color: rgb(33, 111, 219);
+  text-decoration: none;
+}
+.PlaygroundEditorTheme__link:hover {
+  text-decoration: underline;
+  cursor: pointer;
+}
+.PlaygroundEditorTheme__code {
+  background-color: rgb(240, 242, 245);
+  font-family: Menlo, Consolas, Monaco, monospace;
+  display: block;
+  padding: 8px 8px 28px 52px;
+  line-height: 1.53;
+  font-size: 13px;
+  margin: 0;
+  margin-top: 8px;
+  margin-bottom: 8px;
+  overflow-x: auto;
+  position: relative;
+  tab-size: 2;
+}
+.PlaygroundEditorTheme__code:before {
+  content: attr(data-gutter);
+  position: absolute;
+  background-color: #eee;
+  left: 0;
+  top: 0;
+  border-right: 1px solid #ccc;
+  padding: 8px;
+  color: #777;
+  white-space: pre-wrap;
+  text-align: right;
+  min-width: 25px;
+}
+.PlaygroundEditorTheme__table {
+  border-collapse: collapse;
+  border-spacing: 0;
+  overflow-y: scroll;
+  overflow-x: scroll;
+  table-layout: fixed;
+  width: max-content;
+  margin: 30px 0;
+}
+.PlaygroundEditorTheme__tableSelection *::selection {
+  background-color: transparent;
+}
+.PlaygroundEditorTheme__tableSelected {
+  outline: 2px solid rgb(60, 132, 244);
+}
+.PlaygroundEditorTheme__tableCell {
+  border: 1px solid #bbb;
+  width: 75px;
+  min-width: 75px;
+  vertical-align: top;
+  text-align: start;
+  padding: 6px 8px;
+  position: relative;
+  outline: none;
+}
+.PlaygroundEditorTheme__tableCellSortedIndicator {
+  display: block;
+  opacity: 0.5;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 4px;
+  background-color: #999;
+}
+.PlaygroundEditorTheme__tableCellResizer {
+  position: absolute;
+  right: -4px;
+  height: 100%;
+  width: 8px;
+  cursor: ew-resize;
+  z-index: 10;
+  top: 0;
+}
+.PlaygroundEditorTheme__tableCellHeader {
+  background-color: #f2f3f5;
+  text-align: start;
+}
+.PlaygroundEditorTheme__tableCellSelected {
+  background-color: #c9dbf0;
+}
+.PlaygroundEditorTheme__tableCellPrimarySelected {
+  border: 2px solid rgb(60, 132, 244);
+  display: block;
+  height: calc(100% - 2px);
+  position: absolute;
+  width: calc(100% - 2px);
+  left: -1px;
+  top: -1px;
+  z-index: 2;
+}
+.PlaygroundEditorTheme__tableCellEditing {
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.4);
+  border-radius: 3px;
+}
+.PlaygroundEditorTheme__tableAddColumns {
+  position: absolute;
+  top: 0;
+  width: 20px;
+  background-color: #eee;
+  height: 100%;
+  right: -25px;
+  animation: table-controls 0.2s ease;
+  border: 0;
+  cursor: pointer;
+}
+.PlaygroundEditorTheme__characterLimit {
+  display: inline;
+  background-color: #ffbbbb !important;
+}
+.PlaygroundEditorTheme__ol1 {
+  padding: 0;
+  margin: 0;
+  list-style-position: inside;
+  list-style-type: decimal;
+}
+.PlaygroundEditorTheme__ol2 {
+  padding: 0;
+  margin: 0;
+  list-style-type: upper-alpha;
+  list-style-position: inside;
+}
+.PlaygroundEditorTheme__ol3 {
+  padding: 0;
+  margin: 0;
+  list-style-type: lower-alpha;
+  list-style-position: inside;
+}
+.PlaygroundEditorTheme__ol4 {
+  padding: 0;
+  margin: 0;
+  list-style-type: upper-roman;
+  list-style-position: inside;
+}
+.PlaygroundEditorTheme__ol5 {
+  padding: 0;
+  margin: 0;
+  list-style-type: lower-roman;
+  list-style-position: inside;
+}
+.PlaygroundEditorTheme__ul {
+  padding: 0;
+  margin: 0;
+  list-style-position: inside;
+  list-style: disc;
+}
+.PlaygroundEditorTheme__listItem {
+  margin: 0 32px;
+}
+.PlaygroundEditorTheme__listItemChecked,
+.PlaygroundEditorTheme__listItemUnchecked {
+  position: relative;
+  margin-left: 8px;
+  margin-right: 8px;
+  padding-left: 24px;
+  padding-right: 24px;
+  list-style-type: none;
+  outline: none;
+}
+.PlaygroundEditorTheme__listItemChecked {
+  text-decoration: line-through;
+}
+.PlaygroundEditorTheme__listItemUnchecked:before,
+.PlaygroundEditorTheme__listItemChecked:before {
+  content: '';
+  width: 16px;
+  height: 16px;
+  top: 2px;
+  left: 0;
+  cursor: pointer;
+  display: block;
+  background-size: cover;
+  position: absolute;
+}
+.PlaygroundEditorTheme__listItemUnchecked[dir='rtl']:before,
+.PlaygroundEditorTheme__listItemChecked[dir='rtl']:before {
+  left: auto;
+  right: 0;
+}
+.PlaygroundEditorTheme__listItemUnchecked:focus:before,
+.PlaygroundEditorTheme__listItemChecked:focus:before {
+  box-shadow: 0 0 0 2px #a6cdfe;
+  border-radius: 2px;
+}
+.PlaygroundEditorTheme__listItemUnchecked:before {
+  border: 1px solid #999;
+  border-radius: 2px;
+}
+.PlaygroundEditorTheme__listItemChecked:before {
+  border: 1px solid rgb(61, 135, 245);
+  border-radius: 2px;
+  background-color: #3d87f5;
+  background-repeat: no-repeat;
+}
+.PlaygroundEditorTheme__listItemChecked:after {
+  content: '';
+  cursor: pointer;
+  border-color: #fff;
+  border-style: solid;
+  position: absolute;
+  display: block;
+  top: 6px;
+  width: 3px;
+  left: 7px;
+  right: 7px;
+  height: 6px;
+  transform: rotate(45deg);
+  border-width: 0 2px 2px 0;
+}
+.PlaygroundEditorTheme__nestedListItem {
+  list-style-type: none;
+}
+.PlaygroundEditorTheme__nestedListItem:before,
+.PlaygroundEditorTheme__nestedListItem:after {
+  display: none;
+}
+.PlaygroundEditorTheme__tokenComment {
+  color: slategray;
+}
+.PlaygroundEditorTheme__tokenPunctuation {
+  color: #999;
+}
+.PlaygroundEditorTheme__tokenProperty {
+  color: #905;
+}
+.PlaygroundEditorTheme__tokenSelector {
+  color: #690;
+}
+.PlaygroundEditorTheme__tokenOperator {
+  color: #9a6e3a;
+}
+.PlaygroundEditorTheme__tokenAttr {
+  color: #07a;
+}
+.PlaygroundEditorTheme__tokenVariable {
+  color: #e90;
+}
+.PlaygroundEditorTheme__tokenFunction {
+  color: #dd4a68;
+}
+.PlaygroundEditorTheme__mark {
+  background: rgba(255, 212, 0, 0.14);
+  border-bottom: 2px solid rgba(255, 212, 0, 0.3);
+  padding-bottom: 2px;
+}
+.PlaygroundEditorTheme__markOverlap {
+  background: rgba(255, 212, 0, 0.3);
+  border-bottom: 2px solid rgba(255, 212, 0, 0.7);
+}
+.PlaygroundEditorTheme__mark.selected {
+  background: rgba(255, 212, 0, 0.5);
+  border-bottom: 2px solid rgba(255, 212, 0, 1);
+}
+.PlaygroundEditorTheme__markOverlap.selected {
+  background: rgba(255, 212, 0, 0.7);
+  border-bottom: 2px solid rgba(255, 212, 0, 0.7);
+}
+.PlaygroundEditorTheme__embedBlock {
+  user-select: none;
+}
+.PlaygroundEditorTheme__embedBlockFocus {
+  outline: 2px solid rgb(60, 132, 244);
+}
+.PlaygroundEditorTheme__layoutContainer {
+  display: grid;
+  gap: 10px;
+  margin: 10px 0;
+}
+.PlaygroundEditorTheme__layoutItem {
+  border: 1px dashed #ddd;
+  padding: 8px 16px;
+}

--- a/ui/src/styles/editor.css
+++ b/ui/src/styles/editor.css
@@ -1,0 +1,41 @@
+.editor {
+  margin: 20px auto;
+  max-width: 1024px;
+  color: #000;
+  position: relative;
+  line-height: 1.7;
+  font-weight: 400;
+}
+
+.placeholder {
+  @apply pointer-events-none absolute top-0 opacity-50;
+}
+
+/*  editor 랑 content editable 사이에 요소 추가될 때 필요함 ex 상단 툴바
+.editor-container {
+  background: #fff;
+  position: relative;
+  display: block;
+  border-bottom-left-radius: 10px;
+  border-bottom-right-radius: 10px;
+} */
+
+.content-editable-wrapper {
+  min-height: 150px;
+  border: 0;
+  display: flex;
+  position: relative;
+  outline: 0;
+  z-index: 0;
+  overflow: auto;
+}
+
+.content-editable {
+  flex: auto;
+  position: relative;
+  z-index: -1;
+}
+
+.content-editable div:focus {
+  outline: 0;
+}


### PR DESCRIPTION
resolves #163 

# Changes

- [Lexical](https://lexical.dev/) 사용한 간단한 WYSIWYG 에디터 컴포넌트를 추가합니다.
    - 다른 플러그인들은 후속 PR에서 추가 예정입니다. (ex. 인덴트, 히스토리, ...)
- Lexical은 Rich Text에대해 WYSIWYG을 다음의 방식으로 지원합니다:
    - Lexical은 키 입력이나 붙여넣기를 통해 받아들인 인풋을 노드 단위로 변환합니다.
    - 변환한다는 것은 해당 노드에 해당하는 DOM 노드를 생성해 내는 것이고,
    - 이때, 각 노드들이 갖고있는 `createDOM`, `importDOM` 매서드를 사용합니다.
    - 이 메서드들 내부에서 theme 을 통해 주입한 스타일을 각 DOM 노드의 클래스로 매핑합니다.
    - `MarkdownShortcutPlugin` 은 내부적으로 regex를 활용하여 입력된 인풋이 어떤 노드에 해당하는지 찾아내어 편집 중 실시간(Shortcut)으로 변환이 일어나게 해주는 플러그인 입니다.
- theme의 경우, #133 과 관련한 논의대로 editor state를 db에 저장하면서 theme은 추후에 유연하게 변경 가능하므로 우선 동작확인을 위해 [Lexical playground의 css 코드](https://github.com/facebook/lexical/blob/main/packages/lexical-playground/src/themes/PlaygroundEditorTheme.css)를 사용했습니다.