### PR TITLE
[#171] Make Button for sign in and out work

### DIFF
--- a/ui/next.config.mjs
+++ b/ui/next.config.mjs
@@ -3,6 +3,8 @@ import bundleAnalzer from '@next/bundle-analyzer';
 const withBundleAnalzyer = bundleAnalzer({ enabled: process.env.ANALYZE === 'true' });
 
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  rewrites: () => [{ source: '/api/:path*', destination: 'http://localhost:8080/api/:path*' }],
+};
 
 export default withBundleAnalzyer(nextConfig);

--- a/ui/src/components/layout/header.tsx
+++ b/ui/src/components/layout/header.tsx
@@ -9,8 +9,7 @@ export function Header() {
   const isLoggedIn = !!cookies().get('mrcToken');
 
   return (
-    <header className="sticky top-0 flex w-full items-center gap-4 border-b px-6 py-4">
-      <div className="absolute inset-0 -z-10 w-full bg-white/30 backdrop-blur-sm" />
+    <header className="z-20 flex w-full items-center gap-4 border-b bg-white px-6 py-4">
       <div className="block">
         <Link href="/" scroll={false}>
           <Logo />

--- a/ui/src/components/layout/header.tsx
+++ b/ui/src/components/layout/header.tsx
@@ -1,10 +1,13 @@
 import { NavLinks } from '@/components/layout/nav-links';
 import Logo from '@/components/logo';
 import SideBar from '@/components/layout/sidebar';
-import Text from '@/components/atomic/text';
 import Link from 'next/link';
+import { SignButton } from '@/components/layout/sign-button';
+import { cookies } from 'next/headers';
 
 export function Header() {
+  const isLoggedIn = !!cookies().get('mrcToken');
+
   return (
     <header className="sticky top-0 flex w-full items-center gap-4 border-b px-6 py-4">
       <div className="absolute inset-0 -z-10 w-full bg-white/30 backdrop-blur-sm" />
@@ -17,22 +20,11 @@ export function Header() {
         <nav className="hidden items-center gap-4 sm:flex">
           <NavLinks />
         </nav>
-        <SignButton />
+        <SignButton isLoggedIn={isLoggedIn} />
         <nav className="flex items-center sm:hidden">
-          <SideBar SignButton={<SignButton />} />
+          <SideBar SignButton={<SignButton isLoggedIn={isLoggedIn} />} />
         </nav>
       </div>
     </header>
-  );
-}
-
-function SignButton() {
-  return (
-    // TODO: use server action
-    <form className="hover:cursor-pointer">
-      <Text size="lg" weight="medium">
-        Sign In
-      </Text>
-    </form>
   );
 }

--- a/ui/src/components/layout/sidebar.tsx
+++ b/ui/src/components/layout/sidebar.tsx
@@ -17,8 +17,8 @@ export default function Sidebar({ SignButton }: { SignButton: JSX.Element }) {
       </button>
       {isOpen && (
         <>
-          <div className="fixed inset-0 bg-black/20" onClick={() => setIsOpen(false)} />
-          <div className="fixed right-0 top-0 flex h-screen flex-col gap-4 bg-white px-6 py-4">
+          <div className="fixed inset-0 z-20 bg-black/20" onClick={() => setIsOpen(false)} />
+          <div className="fixed right-0 top-0 z-20 flex h-screen flex-col gap-4 bg-white px-6 py-4">
             {/* TODO: h-[52px] is for temporal LOGO size. */}
             <div className="flex h-[52px] items-center gap-4">
               {SignButton}

--- a/ui/src/components/layout/sign-button.tsx
+++ b/ui/src/components/layout/sign-button.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import Text from '@/components/atomic/text';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+export function SignButton({ isLoggedIn }: { isLoggedIn: boolean }) {
+  const router = useRouter();
+
+  if (isLoggedIn) {
+    return (
+      <button
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        onClick={async () => {
+          const res = await fetch('/api/v1/auth/sign-out');
+
+          if (res.ok) {
+            router.refresh();
+          } else {
+            // TODO: handle error - emit error toast ?
+          }
+        }}
+      >
+        <Text size="lg" weight="medium">
+          Sign Out
+        </Text>
+      </button>
+    );
+  }
+
+  return (
+    <Link className="hover:cursor-pointer" href="/api/v1/google/sign-in">
+      <Text size="lg" weight="medium">
+        Sign In
+      </Text>
+    </Link>
+  );
+}


### PR DESCRIPTION
#171

# Changes

- 로그인 로그아웃이 동작하고 로그인 로그아웃 상태에 맞춰 버튼이 표기됩니다.
- 현재 로그인 여부를 server side 에서 [cookies api](https://nextjs.org/docs/app/api-reference/functions/cookies) 로 `mrcToken` 유무를 확인 후  prop으로 내려주는데,
- 이 부분은 userId param 이 필요없는 API 가 추가 되면 client side 에서 그 api의 응답을 이용하도록 변경 예정입니다.