### PR TITLE
[#171] Add auth context 

### DIFF
--- a/ui/.env
+++ b/ui/.env
@@ -1,0 +1,1 @@
+BACKEND_URL='http://localhost:8080'

--- a/ui/.eslintrc.cjs
+++ b/ui/.eslintrc.cjs
@@ -11,7 +11,6 @@ module.exports = {
     'next/core-web-vitals',
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended-type-checked',
-    'plugin:@typescript-eslint/stylistic-type-checked',
     'plugin:storybook/recommended',
   ],
   rules: {},
@@ -21,5 +20,4 @@ module.exports = {
  * References
  * https://typescript-eslint.io/linting/configs/#projects-with-type-checking
  * https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/recommended-type-checked.ts
- * https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/stylistic-type-checked.ts
  */

--- a/ui/next.config.mjs
+++ b/ui/next.config.mjs
@@ -4,7 +4,7 @@ const withBundleAnalzyer = bundleAnalzer({ enabled: process.env.ANALYZE === 'tru
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  rewrites: () => [{ source: '/api/:path*', destination: 'http://localhost:8080/api/:path*' }],
+  rewrites: () => [{ source: '/api/:path*', destination: `${process.env.BACKEND_URL}/api/:path*` }],
 };
 
 export default withBundleAnalzyer(nextConfig);

--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import '@/styles/globals.css';
 import { notoSansKr } from '@/fonts';
+import { AuthProvider } from '@/context/auth-context';
 
 export const metadata: Metadata = {
   title: 'Home',
@@ -16,7 +17,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={`${notoSansKr.className} antialiased`}>{children}</body>
+      <body className={`${notoSansKr.className} antialiased`}>
+        <AuthProvider>{children}</AuthProvider>
+      </body>
     </html>
   );
 }

--- a/ui/src/components/layout/header.tsx
+++ b/ui/src/components/layout/header.tsx
@@ -2,12 +2,9 @@ import { NavLinks } from '@/components/layout/nav-links';
 import Logo from '@/components/logo';
 import SideBar from '@/components/layout/sidebar';
 import Link from 'next/link';
-import { SignButton } from '@/components/layout/sign-button';
-import { cookies } from 'next/headers';
+import SignButton from '@/components/layout/sign-button';
 
 export function Header() {
-  const isLoggedIn = !!cookies().get('mrcToken');
-
   return (
     <header className="z-20 flex w-full items-center gap-4 border-b bg-white px-6 py-4">
       <div className="block">
@@ -19,9 +16,9 @@ export function Header() {
         <nav className="hidden items-center gap-4 sm:flex">
           <NavLinks />
         </nav>
-        <SignButton isLoggedIn={isLoggedIn} />
+        <SignButton />
         <nav className="flex items-center sm:hidden">
-          <SideBar SignButton={<SignButton isLoggedIn={isLoggedIn} />} />
+          <SideBar SignButton={<SignButton />} />
         </nav>
       </div>
     </header>

--- a/ui/src/components/layout/sign-button.tsx
+++ b/ui/src/components/layout/sign-button.tsx
@@ -1,24 +1,17 @@
 'use client';
 
 import Text from '@/components/atomic/text';
-import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useAuth } from '@/context/auth-context';
 
-export function SignButton({ isLoggedIn }: { isLoggedIn: boolean }) {
-  const router = useRouter();
+export default function SignButton() {
+  const { user, signOut, signIn } = useAuth();
 
-  if (isLoggedIn) {
+  if (user) {
     return (
       <button
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         onClick={async () => {
-          const res = await fetch('/api/v1/auth/sign-out');
-
-          if (res.ok) {
-            router.refresh();
-          } else {
-            // TODO: handle error - emit error toast ?
-          }
+          await signOut();
         }}
       >
         <Text size="lg" weight="medium">
@@ -29,10 +22,10 @@ export function SignButton({ isLoggedIn }: { isLoggedIn: boolean }) {
   }
 
   return (
-    <Link className="hover:cursor-pointer" href="/api/v1/google/sign-in">
+    <button onClick={() => signIn()}>
       <Text size="lg" weight="medium">
         Sign In
       </Text>
-    </Link>
+    </button>
   );
 }

--- a/ui/src/context/auth-context.tsx
+++ b/ui/src/context/auth-context.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { fetchSignOut, fetchUser, linkToSignIn } from '@/lib/apis/auth';
+import { User } from '@/lib/definitions/user';
+import { ReactNode, createContext, useContext, useEffect, useState } from 'react';
+
+interface ContextShape {
+  user?: User;
+  signOut: () => Promise<void>;
+  signIn: () => void;
+}
+
+const AuthContext = createContext<ContextShape | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User>();
+
+  useEffect(() => {
+    // why void?
+    // we don't handle fetchUser error
+    // becuase failure to fetch user is just considered
+    // to be signed out.
+    void fetchUser().then(setUser);
+  }, []);
+
+  const signOut = async () => {
+    await fetchSignOut();
+    void fetchUser().then(setUser);
+  };
+
+  const signIn = () => {
+    linkToSignIn();
+  };
+
+  return <AuthContext.Provider value={{ user, signOut, signIn }}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+
+  return context;
+}

--- a/ui/src/context/auth-context.tsx
+++ b/ui/src/context/auth-context.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { fetchSignOut, fetchUser, linkToSignIn } from '@/lib/apis/auth';
+import { fetchSignOut, getUserSelf, linkToSignIn } from '@/lib/apis/auth';
 import { User } from '@/lib/definitions/user';
 import { ReactNode, createContext, useContext, useEffect, useState } from 'react';
 
@@ -17,15 +17,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     // why void?
-    // we don't handle fetchUser error
-    // becuase failure to fetch user is just considered
+    // we don't handle getUserSelf error
+    // becuase failure to getUserSelf is just considered
     // to be signed out.
-    void fetchUser().then(setUser);
+    void getUserSelf().then(setUser);
   }, []);
 
   const signOut = async () => {
     await fetchSignOut();
-    void fetchUser().then(setUser);
+    void getUserSelf().then(setUser);
   };
 
   const signIn = () => {

--- a/ui/src/lib/apis/auth.ts
+++ b/ui/src/lib/apis/auth.ts
@@ -1,6 +1,6 @@
 import { User } from '@/lib/definitions/user';
 
-export async function fetchUser() {
+export async function getUserSelf() {
   const response = await fetch('/api/v1/users/self');
 
   if (!response.ok) {

--- a/ui/src/lib/apis/auth.ts
+++ b/ui/src/lib/apis/auth.ts
@@ -1,0 +1,25 @@
+import { User } from '@/lib/definitions/user';
+
+export async function fetchUser() {
+  const response = await fetch('/api/v1/users/self');
+
+  if (!response.ok) {
+    return;
+  }
+
+  const data = (await response.json()) as { user: User };
+  return data.user;
+}
+
+export async function fetchSignOut() {
+  const response = await fetch('/api/v1/auth/sign-out');
+
+  if (!response.ok) {
+    // TODO: handle error
+    throw new Error('fail to sign out');
+  }
+}
+
+export function linkToSignIn() {
+  window.location.href = '/api/v1/google/sign-in';
+}

--- a/ui/src/lib/definitions/user.ts
+++ b/ui/src/lib/definitions/user.ts
@@ -1,13 +1,14 @@
-type Idp = 'google';
+type Idp = 'GOOGLE';
 
 export type AccessLevel = 'USER' | 'DEVELOPER' | 'ADMIN';
 
-interface User {
+export interface User {
   id: string; // uuid
   nickname: string; // "신비로운 평론가 붉은 여우"
   tag: string; // "MQ3B"
   idp: Idp;
+  email: string;
   accessLevel: AccessLevel;
+  createdAt: string;
+  updatedAt: string;
 }
-
-export type GetUserDetailResponse = User;

--- a/ui/src/lib/dummy/user.ts
+++ b/ui/src/lib/dummy/user.ts
@@ -1,13 +1,16 @@
 // TODO: Remove dummy after connected with backend apis
 
-import type { GetUserDetailResponse } from '@/lib/definitions/user';
+import type { User } from '@/lib/definitions/user';
 
-const dummyUserDetailResponse: GetUserDetailResponse = {
+const dummyUser: User = {
   id: '7289ae9c-42b1-49ca-8f5b-a1831583e903',
   nickname: '신비로운 평론가 붉은 여우',
   tag: '#MQ3B',
-  idp: 'google',
+  idp: 'GOOGLE',
   accessLevel: 'USER',
+  email: 'hello@world.com',
+  createdAt: '2023-04-02T15:08:00+09:00',
+  updatedAt: '2023-04-02T15:08:00+09:00',
 };
 
-export default dummyUserDetailResponse;
+export default dummyUser;


### PR DESCRIPTION
#171

# Changes

- 모노레포 구조로 프로젝트 세팅 당시 타입검사를 eslint 에게 온전히 맡기려고 상당히 strict 한 lint 룰을 설정했었는데, 너무 strict 한 플러그인 때문에 next와 react의 몇가지 기능들(특히 server action 관련)을 구현하면서 `eslint-disable` 주석이 빈번하게 필요합니다. 따라서 현재 프로젝트와 맞지않는 lint rule이라 판단되는 플러그인 `@typescript-eslint/stylistic-type-checked` 를 제거합니다.
- `User` definition을 현재 api 응답에 맞게 수정했습니다.
- 현재 로그인 여부를 확인하는 시나리오는 다음과 같습니다:
    - `getUserSelf`를 호출한다.
    - 성공 시 쿠키가 세팅되어있는 로그인 상태, 
    - 실패 시 로그아웃으로 판단한다
- 이 과정에서 로그아웃 상태인 경우 `getUserSelf` 요청의 실패에 대한 메세지가 콘솔에 나타나게됩니다. 

https://github.com/MovieReviewComment/Mr.C/assets/40269597/80acadd2-fd1d-4469-bbb3-47bd7de256a1


- 이를 막으려면 catch 문안에서 `console.clear()` 호출을 하도록 해야하는데 굳이 필요할 지 의견이 필요합니다. (ref: https://stackoverflow.com/questions/4500741/suppress-chrome-failed-to-load-resource-messages-in-console)