### PR TITLE
[#162] Prepare util functions for SearchForm

### DIFF
--- a/ui/src/components/user-chip.tsx
+++ b/ui/src/components/user-chip.tsx
@@ -1,21 +1,16 @@
 'use client';
 
 import Text from '@/components/atomic/text';
-import { useOutsideClick } from '@/hooks/use-outside-click';
-import { useRef, useState } from 'react';
+import { useDropdown } from '@/hooks/use-dropdown';
 
 export default function UserChip({ nickname, tag }: { nickname: string; tag: string }) {
-  const [isDropdownOpen, setDropdownOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  const handleClick = () => setDropdownOpen((prev) => !prev);
-  useOutsideClick({ ref, handler: () => setDropdownOpen(false) });
+  const { targetRef, toggleDropdown, isDropdownOpen } = useDropdown<HTMLDivElement>();
 
   return (
-    <div ref={ref} className="relative">
+    <div ref={targetRef} className="relative">
       <div
         className="flex w-fit items-center rounded bg-gray-100 px-1 hover:bg-gray-200"
-        onClick={handleClick}
+        onClick={toggleDropdown}
         data-testid="user-chip"
       >
         <Text weight="medium" nowrap>

--- a/ui/src/context/filters-context.tsx
+++ b/ui/src/context/filters-context.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import { ReactNode, createContext, useContext, useState } from 'react';
+
+interface ContextShape {
+  filters: string[];
+  selectedFilters: string[];
+  unselectedFilters: string[];
+  selectFilter: (target: string) => void;
+  unselectFilter: (target: string) => void;
+  changeFilter: (from: string, to: string) => void;
+  getFilterValue: (target: string) => string;
+  setFilterValue: (filter: string, value: string) => void;
+}
+
+const FiltersContext = createContext<ContextShape | null>(null);
+
+export function FiltersProvider({ children, filters }: { children: ReactNode; filters: string[] }) {
+  const searchParams = useSearchParams();
+  const filtersFromURL = filters.filter((filter) => searchParams.has(filter));
+
+  // Should be array because order is important here !
+  const initialParams: [string, string][] = [];
+
+  if (filtersFromURL.length > 0) {
+    for (const filter of filtersFromURL) {
+      initialParams.push([filter, searchParams.get(filter) ?? '']);
+    }
+  } else {
+    initialParams.push([filters[0], '']);
+  }
+  const [params, setParams] = useState(initialParams);
+
+  const selectedFilters = params.map((v) => v[0]);
+  const unselectedFilters = filters.filter((filter) => !selectedFilters.includes(filter));
+
+  const selectFilter = (target: string) => setParams((prev) => [...prev, [target, '']]);
+
+  const unselectFilter = (target: string) =>
+    setParams((prev) => prev.filter((v) => v[0] !== target));
+
+  const changeFilter = (from: string, to: string) =>
+    setParams((prev) => {
+      const index = prev.findIndex((v) => v[0] === from);
+      return [...prev.slice(0, index), [to, prev[index][1]], ...prev.slice(index + 1)];
+    });
+
+  const getFilterValue = (target: string) => {
+    const index = params.findIndex((v) => v[0] === target);
+    return params[index][1];
+  };
+
+  const setFilterValue = (filter: string, value: string) =>
+    setParams((prev) => {
+      const index = prev.findIndex((v) => v[0] === filter);
+      return [...prev.slice(0, index), [filter, value], ...prev.slice(index + 1)];
+    });
+
+  return (
+    <FiltersContext.Provider
+      value={{
+        filters,
+        selectedFilters,
+        unselectedFilters,
+        selectFilter,
+        unselectFilter,
+        changeFilter,
+        getFilterValue,
+        setFilterValue,
+      }}
+    >
+      {children}
+    </FiltersContext.Provider>
+  );
+}
+
+export function useFilters() {
+  const context = useContext(FiltersContext);
+
+  if (!context) {
+    throw new Error('useFilter must be used within an FilterProvider');
+  }
+
+  return context;
+}

--- a/ui/src/hooks/use-dropdown.ts
+++ b/ui/src/hooks/use-dropdown.ts
@@ -1,0 +1,12 @@
+import { useOutsideClick } from '@/hooks/use-outside-click';
+import { useRef, useState } from 'react';
+
+export function useDropdown<T extends HTMLElement>() {
+  const [isDropdownOpen, setDropdownOpen] = useState(false);
+  const ref = useRef<T>(null);
+
+  const toggleDropdown = () => setDropdownOpen((prev) => !prev);
+  useOutsideClick({ ref, handler: () => setDropdownOpen(false) });
+
+  return { targetRef: ref, isDropdownOpen, toggleDropdown };
+}

--- a/ui/src/hooks/use-search-form-state.ts
+++ b/ui/src/hooks/use-search-form-state.ts
@@ -1,0 +1,52 @@
+'use client';
+
+import { usePathname, useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { useFormState } from 'react-dom';
+
+import { isString } from '@/lib/utils/is-string';
+
+interface SearchFormState {
+  error?: string | null;
+  // todo: this should be an object that contains errors for each field
+  // instead of one error string
+}
+
+export function useSearchFormState(filters: string[]) {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async function searchAction(prevState: SearchFormState, formData: FormData) {
+    const params = new URLSearchParams();
+
+    for (const filter of filters) {
+      const data = formData.get(filter);
+
+      if (data) {
+        if (!isString(data)) {
+          return { error: `${filter} data should be string but is ${typeof data}` };
+          // todo: handle error properly
+          // todo: handle length error after deciding policy
+        }
+
+        const trimmed = data.trim();
+        if (trimmed) params.set(filter, trimmed);
+      }
+    }
+
+    router.push(`${pathname}?${params.toString()}`);
+    return { error: null };
+  }
+
+  const initialState: SearchFormState = { error: null };
+  const [state, formAction] = useFormState(searchAction, initialState);
+
+  useEffect(() => {
+    if (state?.error) {
+      alert(state.error); // todo: replace with emitting toast
+    }
+  }, [state]);
+
+  return { formAction };
+}

--- a/ui/src/lib/utils/is-string.ts
+++ b/ui/src/lib/utils/is-string.ts
@@ -1,0 +1,3 @@
+export function isString(param: unknown): param is string {
+  return typeof param === 'string';
+}


### PR DESCRIPTION
#162 

# Changes

- `SearchForm` 컴포넌트에 필요한 유틸 함수들입니다.
-  `useDropdown`: `UserChip` 에서 사용한 dropdown 관련 훅들을 재사용을 위해 분리했습니다.
- `FiltersContext`: prop으로 설정된 filter 들을 url 에서 읽어와 초기화 하고, 상태로 관리합니다.
    - 유저가 각 filter를 다룰 때, 순서가 뒤죽박죽이 되는 경우를 막기 위해 `Map`이나 `Object`가 아닌 `[string, string][]` 형태의 array를 택했습니다.
- `useSearchFormState`: 유저가 form 제출 시 입력한 filter 를 param으로 설정하여 이동시키기 위한 훅입니다.