### PR TITLE
[#162] Add fallback skeletons for reviews list

### DIFF
--- a/ui/src/app/(board)/review/page.tsx
+++ b/ui/src/app/(board)/review/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react';
 
 import { ReviewBoardHeader } from '@/components/review-board-header';
 import { ReviewCardsList } from '@/components/review-cards-list';
+import { ReviewCardsListSkeleton } from '@/components/skeletons';
 
 import type { ListReviewsQuery } from '@/lib/definitions/review';
 
@@ -24,7 +25,7 @@ export default function Page({
       <ReviewBoardHeader />
 
       <section className="w-full py-4">
-        <Suspense key={JSON.stringify(query)} /* TODO: fallback skeleton */>
+        <Suspense key={JSON.stringify(query)} fallback={<ReviewCardsListSkeleton />}>
           <ReviewCardsList query={query} />
         </Suspense>
       </section>

--- a/ui/src/components/skeletons.tsx
+++ b/ui/src/components/skeletons.tsx
@@ -1,0 +1,60 @@
+import clsx from 'clsx';
+
+// https://delba.dev/blog/animated-loading-skeletons-with-tailwind
+const shimmer = clsx(
+  'relative before:absolute before:inset-0 before:-translate-x-full before:animate-[shimmer_2s_infinite] before:bg-gradient-to-r before:from-transparent before:via-gray-100/60 before:to-transparent'
+);
+
+const skeletonClass = clsx(
+  shimmer,
+  'isolate overflow-hidden rounded-md bg-gray-200 shadow-xl shadow-black/5 before:border-t before:border-gray-100/60'
+);
+
+function UserchipSkeleton() {
+  return <div className={clsx('h-5 w-56 shrink-0 pb-1', skeletonClass)}></div>;
+}
+
+function ReviewCardSkeleton() {
+  return (
+    <div className="flex flex-col border-t p-6 [&:first-child]:border-none">
+      <div className={clsx('mb-1 h-6 w-56', skeletonClass)}></div>
+      <div className={clsx('mb-1 h-5 w-52', skeletonClass)}></div>
+      <div className="mt-4">
+        <div className={clsx('mb-1 h-5 w-full', skeletonClass)}></div>
+        <div className={clsx('mb-1 h-5 w-full', skeletonClass)}></div>
+        <div className={clsx('mb-1 h-5 w-full', skeletonClass)}></div>
+      </div>
+      <div className="mt-4 flex items-center gap-1">
+        <UserchipSkeleton />
+        <p>&#183;</p>
+        <div className={clsx('h-5 w-14 shrink-0 pb-1', skeletonClass)}></div>
+      </div>
+    </div>
+  );
+}
+
+function PaginationSkeleton() {
+  return <div className="h-10"></div>;
+}
+
+export function ReviewCardsListSkeleton() {
+  // TODO: pagination skeleton do paginate with caching totalPagesCount by query ?
+
+  return (
+    <div className={clsx('flex w-full flex-col items-center space-y-6')}>
+      <div className="w-full">
+        <ReviewCardSkeleton />
+        <ReviewCardSkeleton />
+        <ReviewCardSkeleton />
+        <ReviewCardSkeleton />
+        <ReviewCardSkeleton />
+        <ReviewCardSkeleton />
+        <ReviewCardSkeleton />
+        <ReviewCardSkeleton />
+        <ReviewCardSkeleton />
+      </div>
+
+      <PaginationSkeleton />
+    </div>
+  );
+}

--- a/ui/tailwind.config.ts
+++ b/ui/tailwind.config.ts
@@ -3,7 +3,15 @@ import type { Config } from 'tailwindcss';
 const config: Config = {
   content: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
   theme: {
-    extend: {},
+    extend: {
+      keyframes: {
+        shimmer: {
+          '100%': {
+            transform: 'translateX(100%)',
+          },
+        },
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
#162

# Changes

- Review 페이지의 리스트가 nextjs 서버로부터 스트리밍 되는 동안, skeleton UI 가 fallback 으로 보여지게됩니다.
- 스타일링은 Vercel 개발자 Delba의 포스팅을 참고했습니다. 
  (참고: https://delba.dev/blog/animated-loading-skeletons-with-tailwind)