### PR TITLE
[#215] Introduce utils for creating review

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -11,6 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@heroicons/react": "^2.1.1",
+        "@lexical/headless": "^0.13.1",
         "@lexical/react": "^0.13.1",
         "clsx": "^2.1.0",
         "dayjs": "^1.11.10",
@@ -3606,6 +3607,14 @@
         "lexical": "0.13.1"
       }
     },
+    "node_modules/@lexical/headless": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@lexical/headless/-/headless-0.13.1.tgz",
+      "integrity": "sha512-W2mLUuWPrsyf2n73NWM8nKiBI11lEpVVzKE0OzMsjTskv5+AAMaeu1wQ7M1508vKdCcUZwA6AOh3To/hstLEpw==",
+      "peerDependencies": {
+        "lexical": "0.13.1"
+      }
+    },
     "node_modules/@lexical/history": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.13.1.tgz",
@@ -7019,17 +7028,6 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
-    "node_modules/@types/jsdom": {
-      "version": "20.0.1",
-      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
-      "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "@types/tough-cookie": "*",
-        "parse5": "^7.0.0"
-      }
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -7822,18 +7820,6 @@
       },
       "engines": {
         "node": ">=8.9.0"
-      }
-    },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
       }
     },
     "node_modules/aggregate-error": {
@@ -10243,24 +10229,6 @@
       "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
       "dev": true
     },
-    "node_modules/cssstyle": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
-      "dev": true,
-      "dependencies": {
-        "cssom": "~0.3.6"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cssstyle/node_modules/cssom": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-      "dev": true
-    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -10285,20 +10253,6 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
-    },
-    "node_modules/data-urls": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
-      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
-      "dev": true,
-      "dependencies": {
-        "abab": "^2.0.6",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/dayjs": {
       "version": "1.11.10",
@@ -13626,18 +13580,6 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
-    "node_modules/html-encoding-sniffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
-      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
-      "dev": true,
-      "dependencies": {
-        "whatwg-encoding": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/html-entities": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.4.0.tgz",
@@ -13778,38 +13720,11 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "dev": true,
-      "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/https-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
       "dev": true
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -15187,6 +15102,212 @@
         }
       }
     },
+    "node_modules/jest-environment-jsdom/node_modules/@types/jsdom": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
+      "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dev": true,
+      "dependencies": {
+        "cssom": "~0.3.6"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/cssstyle/node_modules/cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true
+    },
+    "node_modules/jest-environment-jsdom/node_modules/data-urls": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "dev": true,
+      "dependencies": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/jsdom": {
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+      "dev": true,
+      "dependencies": {
+        "abab": "^2.0.6",
+        "acorn": "^8.8.1",
+        "acorn-globals": "^7.0.0",
+        "cssom": "^0.5.0",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^3.0.2",
+        "decimal.js": "^10.4.2",
+        "domexception": "^4.0.0",
+        "escodegen": "^2.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.2",
+        "parse5": "^7.1.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0",
+        "ws": "^8.11.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/w3c-xmlserializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "dev": true,
+      "dependencies": {
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/jest-environment-node": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
@@ -16189,51 +16310,6 @@
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.2"
-      }
-    },
-    "node_modules/jsdom": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
-      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
-      "dev": true,
-      "dependencies": {
-        "abab": "^2.0.6",
-        "acorn": "^8.8.1",
-        "acorn-globals": "^7.0.0",
-        "cssom": "^0.5.0",
-        "cssstyle": "^2.3.0",
-        "data-urls": "^3.0.2",
-        "decimal.js": "^10.4.2",
-        "domexception": "^4.0.0",
-        "escodegen": "^2.0.0",
-        "form-data": "^4.0.0",
-        "html-encoding-sniffer": "^3.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.1",
-        "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.2",
-        "parse5": "^7.1.1",
-        "saxes": "^6.0.0",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.2",
-        "w3c-xmlserializer": "^4.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^2.0.0",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^11.0.0",
-        "ws": "^8.11.0",
-        "xml-name-validator": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "canvas": "^2.5.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
       }
     },
     "node_modules/jsesc": {
@@ -22117,18 +22193,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-      "dev": true,
-      "dependencies": {
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -22831,18 +22895,6 @@
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true
     },
-    "node_modules/w3c-xmlserializer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
-      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
-      "dev": true,
-      "dependencies": {
-        "xml-name-validator": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/wait-on": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
@@ -23235,40 +23287,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/whatwg-encoding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
-      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
-      "dev": true,
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/whatwg-mimetype": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-      "dev": true,
-      "dependencies": {
-        "tr46": "^3.0.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -23520,15 +23538,6 @@
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
       "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
       "dev": true
-    },
-    "node_modules/xml-name-validator": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
-      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.1.1",
+    "@lexical/headless": "^0.13.1",
     "@lexical/react": "^0.13.1",
     "clsx": "^2.1.0",
     "dayjs": "^1.11.10",

--- a/ui/src/lib/definitions/review.ts
+++ b/ui/src/lib/definitions/review.ts
@@ -27,3 +27,9 @@ export interface ListReviewsResponse {
 export interface ListReviewsQuery
   extends ReviewFilter,
     Partial<Omit<Pagination, 'totalPageCount'>> {}
+
+export interface CreateReviewRequest {
+  title: string;
+  movieName: string;
+  content: string;
+}

--- a/ui/src/lib/utils/get-review-content.test.ts
+++ b/ui/src/lib/utils/get-review-content.test.ts
@@ -1,0 +1,127 @@
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  type SerializedEditorState,
+  type LexicalEditor,
+  type EditorState,
+} from 'lexical';
+
+import { createHeadlessEditor } from '@lexical/headless';
+
+import { getReviewContent } from '@/lib/utils/get-review-content';
+
+describe('getReviewContent', () => {
+  let editor: LexicalEditor;
+
+  let content: {
+    description: string;
+    serializedEditorState: SerializedEditorState;
+  };
+
+  async function update(updateFn: () => void) {
+    editor.update(updateFn);
+    await Promise.resolve();
+  }
+
+  beforeEach(() => {
+    editor = createHeadlessEditor({
+      onError: (error) => {
+        throw error;
+      },
+    });
+  });
+
+  test('should return all texts joined with space as seperator on description field', async () => {
+    await update(() => {
+      const root = $getRoot();
+
+      root.append($createParagraphNode());
+      root.append($createParagraphNode().append($createTextNode('First Line')));
+      root.append($createParagraphNode());
+      root.append($createParagraphNode());
+      root.append($createParagraphNode());
+      root.append($createParagraphNode());
+      root.append($createParagraphNode());
+      root.append($createParagraphNode().append($createTextNode('Second Line')));
+      root.append($createParagraphNode());
+      root.append($createParagraphNode());
+    });
+
+    const editorState = editor.getEditorState();
+
+    content = getReviewContent(editorState);
+
+    expect(content.description).toBe('First Line Second Line');
+  });
+
+  test('should return content properly', async () => {
+    await update(() => {
+      const root = $getRoot();
+
+      root.append($createParagraphNode().append($createTextNode('First Line')));
+      root.append($createParagraphNode().append($createTextNode('Second Line')));
+    });
+
+    const editorState = editor.getEditorState();
+
+    content = getReviewContent(editorState);
+
+    expect(content).toEqual({
+      description: 'First Line Second Line',
+      serializedEditorState: {
+        root: {
+          children: [
+            {
+              children: [
+                {
+                  detail: 0,
+                  format: 0,
+                  mode: 'normal',
+                  style: '',
+                  text: 'First Line',
+                  type: 'text',
+                  version: 1,
+                },
+              ],
+              direction: null,
+              format: '',
+              indent: 0,
+              type: 'paragraph',
+              version: 1,
+            },
+            {
+              children: [
+                {
+                  detail: 0,
+                  format: 0,
+                  mode: 'normal',
+                  style: '',
+                  text: 'Second Line',
+                  type: 'text',
+                  version: 1,
+                },
+              ],
+              direction: null,
+              format: '',
+              indent: 0,
+              type: 'paragraph',
+              version: 1,
+            },
+          ],
+          direction: null,
+          format: '',
+          indent: 0,
+          type: 'root',
+          version: 1,
+        },
+      },
+    });
+  });
+
+  test('should throw an Error with invalid EditorState', () => {
+    expect(() => getReviewContent({ root: null } as unknown as EditorState)).toThrow(
+      'Lexical Error'
+    );
+  });
+});

--- a/ui/src/lib/utils/get-review-content.ts
+++ b/ui/src/lib/utils/get-review-content.ts
@@ -1,0 +1,17 @@
+import { $nodesOfType, TextNode, type EditorState } from 'lexical';
+
+export function getReviewContent(editorState: EditorState) {
+  try {
+    const description = editorState.read(() => {
+      const textNodes = $nodesOfType(TextNode);
+      return textNodes.map((node) => node.getTextContent()).join(' ');
+    });
+
+    return {
+      description,
+      serializedEditorState: editorState.toJSON(), // toJSON() return valid editorState object
+    };
+  } catch (error) {
+    throw new Error('Lexical Error: not a valid editorState');
+  }
+}

--- a/ui/src/lib/utils/validate-review-fields.test.ts
+++ b/ui/src/lib/utils/validate-review-fields.test.ts
@@ -1,0 +1,159 @@
+import {
+  $getRoot,
+  $createParagraphNode,
+  $createTextNode,
+  type LexicalEditor,
+  type EditorState,
+} from 'lexical';
+
+import { createHeadlessEditor } from '@lexical/headless';
+
+import { validateReviewFields } from '@/lib/utils/validate-review-fields';
+
+describe('validateReviewFields', () => {
+  let editor: LexicalEditor;
+  let rawData: {
+    title: string;
+    movieName: string;
+    editorState: EditorState;
+  };
+
+  async function update(updateFn: () => void) {
+    editor.update(updateFn);
+    await Promise.resolve();
+  }
+
+  beforeEach(() => {
+    editor = createHeadlessEditor({
+      onError: (error) => {
+        throw error;
+      },
+    });
+  });
+
+  test('should return proper CreateReviewReqeust on success ', async () => {
+    await update(() => {
+      $getRoot().append($createParagraphNode().append($createTextNode('hi')));
+    });
+
+    rawData = {
+      title: 'foo',
+      movieName: 'bar',
+      editorState: editor.getEditorState(),
+    };
+
+    expect(validateReviewFields(rawData)).toEqual({
+      success: true,
+      data: {
+        title: 'foo',
+        movieName: 'bar',
+        content:
+          '{"description":"hi","serializedEditorState":{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"hi","type":"text","version":1}],"direction":null,"format":"","indent":0,"type":"paragraph","version":1}],"direction":null,"format":"","indent":0,"type":"root","version":1}}}',
+      },
+    });
+  });
+
+  describe('on fail', () => {
+    test('should return error message for empty title', async () => {
+      await update(() => {
+        $getRoot().append($createParagraphNode().append($createTextNode('hi')));
+      });
+
+      rawData = {
+        title: '',
+        movieName: 'bar',
+        editorState: editor.getEditorState(),
+      };
+
+      expect(validateReviewFields(rawData)).toEqual({
+        success: false,
+        errors: {
+          title: '제목을 입력해주세요.',
+        },
+      });
+    });
+
+    test('should return error message for empty movieTitme', async () => {
+      await update(() => {
+        $getRoot().append($createParagraphNode().append($createTextNode('hi')));
+      });
+
+      rawData = {
+        title: 'foo',
+        movieName: '',
+        editorState: editor.getEditorState(),
+      };
+
+      expect(validateReviewFields(rawData)).toEqual({
+        success: false,
+        errors: {
+          movieName: '영화 제목을 입력해주세요.',
+        },
+      });
+    });
+
+    test('should return error message for empty content', () => {
+      rawData = {
+        title: 'foo',
+        movieName: 'bar',
+        editorState: editor.getEditorState(),
+      };
+
+      expect(validateReviewFields(rawData)).toEqual({
+        success: false,
+        errors: {
+          content: '내용을 입력해주세요.',
+        },
+      });
+    });
+
+    test('should return error message for invalid EditorState', () => {
+      rawData = {
+        title: 'foo',
+        movieName: 'bar',
+        editorState: { root: null } as unknown as EditorState,
+      };
+
+      expect(validateReviewFields(rawData)).toEqual({
+        success: false,
+        errors: {
+          content: '내용을 저장하는 중 오류가 발생했습니다.',
+        },
+      });
+    });
+
+    test('should return error messages for several fields', async () => {
+      rawData = {
+        title: 'foo',
+        movieName: '',
+        editorState: { root: null } as unknown as EditorState,
+      };
+
+      expect(validateReviewFields(rawData)).toEqual({
+        success: false,
+        errors: {
+          movieName: '영화 제목을 입력해주세요.',
+          content: '내용을 저장하는 중 오류가 발생했습니다.',
+        },
+      });
+
+      await update(() => {
+        $getRoot().append($createParagraphNode().append($createTextNode('hi')));
+      });
+
+      rawData = {
+        title: '',
+        movieName: '',
+        editorState: editor.getEditorState(),
+      };
+
+      expect(validateReviewFields(rawData)).toEqual({
+        success: false,
+        errors: {
+          title: '제목을 입력해주세요.',
+          movieName: '영화 제목을 입력해주세요.',
+        },
+      });
+    });
+  });
+});

--- a/ui/src/lib/utils/validate-review-fields.ts
+++ b/ui/src/lib/utils/validate-review-fields.ts
@@ -26,16 +26,11 @@ export function validateReviewFields(rawData: RawReviewField): OnSuccess | OnFai
   const { title, movieName, editorState } = rawData;
 
   if (title.length < 1) {
-    errors.set('title', 'title is empty');
+    errors.set('title', '제목을 입력해주세요.');
   }
 
-  // TODO: validate max length after dicussion
-  // if (title.length > 20) {
-  //   errors.set('title', 'title is too long. it should be less than 20');
-  // }
-
   if (movieName.length < 1) {
-    errors.set('movieName', 'movieName is empty');
+    errors.set('movieName', '영화 제목을 입력해주세요.');
   }
 
   let reviewContent: {
@@ -46,13 +41,13 @@ export function validateReviewFields(rawData: RawReviewField): OnSuccess | OnFai
 
   try {
     if (editorState.read($isRootTextContentEmptyCurry(false))) {
-      errors.set('content', 'content is empty');
+      errors.set('content', '내용을 입력해주세요.');
     }
 
     reviewContent = getReviewContent(editorState);
     serializedContent = JSON.stringify(reviewContent);
   } catch (error) {
-    errors.set('content', 'content has something wrong');
+    errors.set('content', `내용을 저장하는 중 오류가 발생했습니다.`);
   }
 
   if (errors.size > 0) {

--- a/ui/src/lib/utils/validate-review-fields.ts
+++ b/ui/src/lib/utils/validate-review-fields.ts
@@ -1,0 +1,73 @@
+import type { EditorState, SerializedEditorState } from 'lexical';
+import { $isRootTextContentEmptyCurry } from '@lexical/text';
+
+import { getReviewContent } from '@/lib/utils/get-review-content';
+import type { CreateReviewRequest } from '@/lib/definitions/review';
+
+interface RawReviewField {
+  title: string;
+  movieName: string;
+  editorState: EditorState;
+}
+
+interface OnSuccess {
+  success: true;
+  data: CreateReviewRequest;
+}
+
+interface OnFail {
+  success: false;
+  errors: Partial<CreateReviewRequest>;
+}
+
+export function validateReviewFields(rawData: RawReviewField): OnSuccess | OnFail {
+  const errors = new Map<string, string>();
+
+  const { title, movieName, editorState } = rawData;
+
+  if (title.length < 1) {
+    errors.set('title', 'title is empty');
+  }
+
+  // TODO: validate max length after dicussion
+  // if (title.length > 20) {
+  //   errors.set('title', 'title is too long. it should be less than 20');
+  // }
+
+  if (movieName.length < 1) {
+    errors.set('movieName', 'movieName is empty');
+  }
+
+  let reviewContent: {
+    description: string;
+    serializedEditorState: SerializedEditorState;
+  };
+  let serializedContent: string;
+
+  try {
+    if (editorState.read($isRootTextContentEmptyCurry(false))) {
+      errors.set('content', 'content is empty');
+    }
+
+    reviewContent = getReviewContent(editorState);
+    serializedContent = JSON.stringify(reviewContent);
+  } catch (error) {
+    errors.set('content', 'content has something wrong');
+  }
+
+  if (errors.size > 0) {
+    return {
+      success: false,
+      errors: Object.fromEntries(errors),
+    };
+  }
+
+  return {
+    success: true,
+    data: {
+      title,
+      movieName,
+      content: serializedContent!,
+    },
+  };
+}


### PR DESCRIPTION
Resolves #215

# Changes

- `@lexical/headless` 패키지를 추가합니다. 테스트 외에도 SSR을 위해 사용될 예정이라 devDependency 가 아닌 dependency 로 추가 합니다.
- `validateReviewFields` 의 인터페이스는 `zod` 의 `safeParse` 를 참고했습니다. (참고: https://zod.dev/?id=safeparse)
- editorState 의 경우 Lexical Editor 가 돌려준 EditorState 객체임에도 유효하지 않은 경우를 예상했습니다. 이 때 `content: 'content has something wrong'` 를 리턴합니다.
- 다음과 같은 패턴으로 사용됩니다.

```ts
const validatedFields = validateReviewFields({ title, movieName, editorState });

if (!validatedFields.success) {
    setFieldState({ error: validatedFields.errors });
    // ...
    return;
}

setFieldState({ error: null });
void createReviewAndNavigate(validatedFields.data);

```

https://github.com/MovieReviewComment/Mr.C/assets/40269597/25f99aca-4b8f-473c-8376-1de1b1ec80f7


