### PR TITLE
[#219] Modify list comments API response

### DIFF
--- a/api/generate/openapi.json
+++ b/api/generate/openapi.json
@@ -148,9 +148,9 @@
         }
       }
     },
-    "/api/v1/comments/": {
+    "/api/v1/comments": {
       "get": {
-        "operationId": "CommentV1ApiSpec_get_/",
+        "operationId": "CommentV1ApiSpec_get_/comments",
         "tags": [
           "Comment"
         ],
@@ -162,33 +162,11 @@
         ],
         "parameters": [
           {
-            "name": "nickname",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "allowReserved": true
-          },
-          {
-            "name": "movieName",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "allowReserved": true
-          },
-          {
             "name": "sortBy",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
-              "enum": [
-                "createdAt",
-                "movieName"
-              ],
-              "type": "string"
+              "$ref": "#/components/schemas/SortBy"
             }
           },
           {
@@ -218,6 +196,24 @@
             "schema": {
               "type": "number"
             }
+          },
+          {
+            "name": "nickname",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "allowReserved": true
+          },
+          {
+            "name": "movieName",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "allowReserved": true
           }
         ],
         "responses": {
@@ -244,7 +240,7 @@
         }
       },
       "post": {
-        "operationId": "CommentV1ApiSpec_post_/",
+        "operationId": "CommentV1ApiSpec_post_/comments",
         "tags": [
           "Comment"
         ],
@@ -304,7 +300,7 @@
     },
     "/api/v1/comments/{commentId}": {
       "delete": {
-        "operationId": "CommentV1ApiSpec_delete_/{commentId}",
+        "operationId": "CommentV1ApiSpec_delete_/comments/{commentId}",
         "tags": [
           "Comment"
         ],
@@ -348,7 +344,7 @@
         }
       },
       "put": {
-        "operationId": "CommentV1ApiSpec_put_/{commentId}",
+        "operationId": "CommentV1ApiSpec_put_/comments/{commentId}",
         "tags": [
           "Comment"
         ],
@@ -398,160 +394,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/UpdateCommentV1Response"
-                }
-              }
-            }
-          },
-          "default": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HttpErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/comments/test": {
-      "get": {
-        "operationId": "CommentV1ApiSpec_get_/test",
-        "tags": [
-          "Comment"
-        ],
-        "summary": "List comments",
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "nickname",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "allowReserved": true
-          },
-          {
-            "name": "movieName",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "allowReserved": true
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "enum": [
-                "createdAt",
-                "movieName"
-              ],
-              "type": "string"
-            }
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "enum": [
-                "asc",
-                "desc"
-              ],
-              "type": "string"
-            }
-          },
-          {
-            "name": "pageOffset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "number"
-            }
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListCommentsV1Response"
-                }
-              }
-            }
-          },
-          "default": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HttpErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "operationId": "CommentV1ApiSpec_post_/test",
-        "tags": [
-          "Comment"
-        ],
-        "summary": "Create comment",
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "movieName": {
-                    "type": "string"
-                  },
-                  "content": {
-                    "type": "string"
-                  }
-                },
-                "additionalProperties": false,
-                "required": [
-                  "content",
-                  "movieName"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CreateCommentV1Response"
                 }
               }
             }
@@ -863,6 +705,13 @@
         "type": "object",
         "additionalProperties": false
       },
+      "SortBy": {
+        "enum": [
+          "createdAt",
+          "movieName"
+        ],
+        "type": "string"
+      },
       "ListCommentsV1Response": {
         "type": "object",
         "properties": {
@@ -960,13 +809,6 @@
           "updatedAt",
           "userId"
         ]
-      },
-      "SortBy": {
-        "enum": [
-          "createdAt",
-          "movieName"
-        ],
-        "type": "string"
       },
       "Direction": {
         "enum": [

--- a/api/generate/openapi.json
+++ b/api/generate/openapi.json
@@ -162,11 +162,33 @@
         ],
         "parameters": [
           {
+            "name": "nickname",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "allowReserved": true
+          },
+          {
+            "name": "movieName",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "allowReserved": true
+          },
+          {
             "name": "sortBy",
             "in": "query",
-            "required": true,
+            "required": false,
             "schema": {
-              "$ref": "#/components/schemas/SortBy"
+              "enum": [
+                "createdAt",
+                "movieName"
+              ],
+              "type": "string"
             }
           },
           {
@@ -196,24 +218,6 @@
             "schema": {
               "type": "number"
             }
-          },
-          {
-            "name": "nickname",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "allowReserved": true
-          },
-          {
-            "name": "movieName",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "allowReserved": true
           }
         ],
         "responses": {
@@ -705,13 +709,6 @@
         "type": "object",
         "additionalProperties": false
       },
-      "SortBy": {
-        "enum": [
-          "createdAt",
-          "movieName"
-        ],
-        "type": "string"
-      },
       "ListCommentsV1Response": {
         "type": "object",
         "properties": {
@@ -809,6 +806,13 @@
           "updatedAt",
           "userId"
         ]
+      },
+      "SortBy": {
+        "enum": [
+          "createdAt",
+          "movieName"
+        ],
+        "type": "string"
       },
       "Direction": {
         "enum": [

--- a/api/src/controller/http/comment/schema/comment.v1.schema.ts
+++ b/api/src/controller/http/comment/schema/comment.v1.schema.ts
@@ -15,10 +15,10 @@ import { HttpErrorResponse } from '@controller/http/response';
 
 export type CommentV1ApiSpec = Tspec.DefineApiSpec<{
   security: 'jwt';
-  basePath: '/api/v1/comments';
+  basePath: '/api/v1';
   tags: ['Comment'];
   paths: {
-    '/': {
+    '/comments': {
       post: {
         summary: 'Create comment';
         body: CreateCommentV1Request;
@@ -36,7 +36,7 @@ export type CommentV1ApiSpec = Tspec.DefineApiSpec<{
         };
       };
     };
-    '/{commentId}': {
+    '/comments/{commentId}': {
       put: {
         summary: 'Update comment';
         path: { commentId: number };
@@ -51,24 +51,6 @@ export type CommentV1ApiSpec = Tspec.DefineApiSpec<{
         path: { commentId: number };
         responses: {
           200: DeleteCommentV1Response;
-          default: HttpErrorResponse;
-        };
-      };
-    };
-    '/test': {
-      post: {
-        summary: 'Create comment';
-        body: CreateCommentV1Request;
-        responses: {
-          200: CreateCommentV1Response;
-          default: HttpErrorResponse;
-        };
-      };
-      get: {
-        summary: 'List comments';
-        query: ListCommentsV1QueryParameter;
-        responses: {
-          200: ListCommentsV1Response;
           default: HttpErrorResponse;
         };
       };


### PR DESCRIPTION
Resolves #219 

# Changes

- Modify schema to recognize paths regardless of trailing slash
  - `/api/v1/comments` (POST, GET)
- Remove unnecessary paths from schema
  - `/api/v1/comments/test` (POST, GET)