### PR TITLE
[#238] Add createReview

### DIFF
--- a/ui/src/lib/apis/review/client.ts
+++ b/ui/src/lib/apis/review/client.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import type { HttpErrorResponse } from '@/lib/definitions/error';
+import type { CreateReviewRequest, CreateReviewResponse } from '@/lib/definitions/review';
+import dummyReviewList from '@/lib/dummy/review';
+
+export async function createReview(data: CreateReviewRequest): Promise<CreateReviewResponse> {
+  try {
+    const response = await fetch('/api/v1/reviews', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      const { messages } = (await response.json()) as HttpErrorResponse;
+
+      // TODO: build proper error message
+      console.error(
+        `status: ${response.status}\nstatusText: ${response.statusText}\nmessages:\n${messages.join('\n')}`
+      );
+
+      throw new Error('네트워크 오류가 발생했습니다. 다시 시도해주세요.');
+    }
+
+    return (await response.json()) as CreateReviewResponse;
+  } catch (error) {
+    // TODO: DELETE THIS WHEN API IS READY
+    return await new Promise((resolve) =>
+      setTimeout(() => resolve({ review: dummyReviewList.reviews[0] }), 500)
+    );
+  }
+}

--- a/ui/src/lib/definitions/error.ts
+++ b/ui/src/lib/definitions/error.ts
@@ -1,0 +1,3 @@
+export interface HttpErrorResponse {
+  messages: string[];
+}

--- a/ui/src/lib/definitions/review.ts
+++ b/ui/src/lib/definitions/review.ts
@@ -34,3 +34,7 @@ export interface CreateReviewRequest {
   movieName: string;
   content: string;
 }
+
+export interface CreateReviewResponse {
+  review: Review;
+}


### PR DESCRIPTION
#238

# Changes

클라이언트 사이드에서 createReview api를 요청할 함수를 추가합니다.

실패 응답을 받은 경우 다음처럼 에러 메세지를 다루려합니다.
- 개발자 도구의 콘솔에는 백엔드에서 돌려준 정보를 최대한 적어주고, 
- 유저 친화적인 에러 메세지를 던져서 UI 에서 토스트로 처리