### PR TITLE
[#238] Implement EditorRefContext

### DIFF
--- a/ui/src/context/editor/editor-ref-context.tsx
+++ b/ui/src/context/editor/editor-ref-context.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { type LexicalEditor } from 'lexical';
+import {
+  ReactNode,
+  RefCallback,
+  RefObject,
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+} from 'react';
+
+interface ContextShape {
+  editorRef: RefObject<LexicalEditor>;
+  onRef: RefCallback<LexicalEditor>;
+}
+
+const EditorRefContext = createContext<ContextShape | null>(null);
+
+export function EditorRefProvider({ children }: { children: ReactNode }) {
+  const [editorRef, setEditorRef] = useState<{ current: LexicalEditor | null }>({ current: null });
+  const onRef = useCallback((editor: LexicalEditor) => setEditorRef({ current: editor }), []);
+
+  return (
+    <EditorRefContext.Provider value={{ editorRef, onRef }}>{children}</EditorRefContext.Provider>
+  );
+}
+
+export function useEditorRef() {
+  return useContext(EditorRefContext);
+}

--- a/ui/src/editor/plugins/editor-ref/index.tsx
+++ b/ui/src/editor/plugins/editor-ref/index.tsx
@@ -1,0 +1,43 @@
+// https://github.com/facebook/lexical/issues/5700
+
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { LexicalEditor } from 'lexical';
+import { MutableRefObject } from 'react';
+import * as React from 'react';
+
+/**
+ *
+ * Use this plugin to access the editor instance outside of the
+ * LexicalComposer. This can help with things like buttons or other
+ * UI components that need to update or read EditorState but need to
+ * be positioned outside the LexicalComposer in the React tree.
+ */
+export function EditorRefPlugin({
+  editorRef,
+}: {
+  editorRef: React.RefCallback<LexicalEditor> | MutableRefObject<LexicalEditor | null | undefined>;
+}): null {
+  const [editor] = useLexicalComposerContext();
+
+  // https://github.com/facebook/react/issues/18178#issuecomment-596880684
+  React.useEffect(() => {
+    if (typeof editorRef === 'function') {
+      editorRef(editor);
+    } else if (typeof editorRef === 'object') {
+      editorRef.current = editor;
+    }
+
+    // prevent unnecessary updates
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editor]);
+
+  return null;
+}

--- a/ui/src/editor/plugins/index.tsx
+++ b/ui/src/editor/plugins/index.tsx
@@ -1,6 +1,9 @@
 import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin';
 import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary';
 import { ContentEditable } from '@lexical/react/LexicalContentEditable';
+
+import { useEditorRef } from '@/context/editor/editor-ref-context';
+import { EditorRefPlugin } from '@/editor/plugins/editor-ref';
 import { MarkdownShortcutPlugin } from '@/editor/plugins/markdown-shorcut';
 
 function Placeholder() {
@@ -8,6 +11,8 @@ function Placeholder() {
 }
 
 export function Plugins() {
+  const { onRef } = useEditorRef() ?? {};
+
   return (
     <>
       <RichTextPlugin
@@ -22,6 +27,7 @@ export function Plugins() {
         ErrorBoundary={LexicalErrorBoundary}
       />
       <MarkdownShortcutPlugin />
+      {onRef !== undefined && <EditorRefPlugin editorRef={onRef} />}
     </>
   );
 }


### PR DESCRIPTION
#238

# Changes

LexicalComposer의 외부에서 Editor 에 접근하기 위한 Context와 Lexical Plugin을 추가합니다.
예를 들어, LexicalComposer 외부의 버튼을 통해 createReview 요청을 트리거하는 경우를 생각해 볼 수 있습니다.

해당 컴포넌트에서  api 요청 data 필드의 content를 담기위해 에디터의 state를 읽어야하는데, 이때 에디터 데이터에 접근하기위해 이 컨텍스트를 사용하게 됩니다.

state가 아닌 useRef로 관리하는 경우 에디터 객체가 ref 에 담긴 후에 리랜더를 트리거 하지 않습니다. 
따라서 state로 에디터 객체를 관리하는데, 현재 Lexical에서 지원해주는 EditorRefPlugin이 이런 패턴의 구현에서 이슈가 있습니다.
endless update를 트리거하는 이슈인데요.

이 PR의 EditorRefPlugin은 이를 위한 Workaround입니다.  Lexical에 올려둔 PR이 머지되면 드러내겠습니다.
