### PR TITLE
[#233] Implement CreateReviewButton

### DIFF
--- a/ui/src/components/review/client/create-review-button.tsx
+++ b/ui/src/components/review/client/create-review-button.tsx
@@ -20,56 +20,80 @@ export function CreateReviewButton() {
   const { title, movieName, movieNameRef, titleRef, disabled, setDisabled } = useReview();
   const { editorRef } = useEditorRef() ?? {};
 
-  const handleClick = () => {
-    setDisabled(true);
+  const validateAndGetData = () => {
+    if (!editorRef?.current) {
+      return;
+    }
 
-    const editorState = editorRef?.current?.getEditorState();
+    const editorState = editorRef.current.getEditorState();
 
-    if (editorState) {
-      const validatedFields = validateReviewFields({ title, movieName, editorState });
+    const validatedFields = validateReviewFields({ title, movieName, editorState });
 
-      if (!validatedFields.success) {
-        // Order to check should be aligned with the order of elements in the DOM
-        // title -> movieName -> editor
-        if (validatedFields.errors.title) {
-          titleRef.current?.focus();
-          emitToast(validatedFields.errors.title, 'error');
-        } else if (validatedFields.errors.movieName) {
-          movieNameRef.current?.focus();
-          emitToast(validatedFields.errors.movieName, 'error');
-        } else {
-          editorRef?.current?.focus();
-          emitToast(validatedFields.errors.content!, 'error');
-        }
-
-        setDisabled(false);
-        return;
+    if (!validatedFields.success) {
+      // Order to check should be aligned with the order of elements in the DOM
+      // title -> movieName -> editor
+      if (validatedFields.errors.title) {
+        titleRef.current?.focus();
+        emitToast(validatedFields.errors.title, 'error');
+      } else if (validatedFields.errors.movieName) {
+        movieNameRef.current?.focus();
+        emitToast(validatedFields.errors.movieName, 'error');
+      } else {
+        editorRef?.current?.focus();
+        emitToast(validatedFields.errors.content!, 'error');
       }
 
-      void createReview(validatedFields.data)
-        .then(({ review }) => {
-          emitToast('리뷰 등록 완료', 'success');
-          router.push(`/review/${review.id}`);
-        })
-        .catch((error) => {
-          if (isErrorWithMessage(error)) {
-            emitToast(error.message, 'error');
-          } else {
-            // TODO: throw new Error and move to global error handler
-            console.error(error);
-            emitToast('알 수 없는 에러가 발생했습니다. 다시 시도해주세요.', 'error');
-          }
-        })
-        .finally(() => setDisabled(false));
+      setDisabled(false);
+      return;
+    }
+
+    return validatedFields.data;
+  };
+
+  const handleApiError = (error: unknown) => {
+    if (isErrorWithMessage(error)) {
+      emitToast(error.message, 'error');
+    } else {
+      // TODO: throw new Error and move to global error handler
+      console.error(error);
+      emitToast('알 수 없는 에러가 발생했습니다. 다시 시도해주세요.', 'error');
     }
   };
 
-  const className = clsx(' rounded-full border bg-white px-2 py-1', {
-    'pointer-events-none': disabled,
-  });
+  const handleCreateReview = async () => {
+    setDisabled(true);
+
+    const data = validateAndGetData();
+
+    if (!data) {
+      return;
+    }
+
+    try {
+      const { review } = await createReview(data);
+
+      emitToast('리뷰 등록 완료', 'success');
+      router.push(`/review/${review.id}`);
+    } catch (error) {
+      handleApiError(error);
+    } finally {
+      setDisabled(false);
+    }
+  };
+
+  const handleClick = () => {
+    void handleCreateReview();
+  };
 
   return (
-    <button className={className} onClick={handleClick} aria-disabled={disabled}>
+    <button
+      role="button"
+      className={clsx('rounded-full border bg-white px-2 py-1', {
+        'pointer-events-none': disabled,
+      })}
+      onClick={handleClick}
+      aria-disabled={disabled}
+    >
       <Text>등록하기</Text>
     </button>
   );

--- a/ui/src/components/review/client/create-review-button.tsx
+++ b/ui/src/components/review/client/create-review-button.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import clsx from 'clsx';
+import { useRouter } from 'next/navigation';
+
+import Text from '@/components/common/server/text';
+
+import { useToast } from '@/context/common/toast-context';
+import { useReview } from '@/context/review/review-context';
+import { useEditorRef } from '@/context/editor/editor-ref-context';
+
+import { createReview } from '@/lib/apis/review/client';
+import { validateReviewFields } from '@/lib/utils/review/validate-review-fields';
+import { isErrorWithMessage } from '@/lib/utils/common/error';
+
+export function CreateReviewButton() {
+  const router = useRouter();
+  const { emitToast } = useToast();
+
+  const { title, movieName, movieNameRef, titleRef, disabled, setDisabled } = useReview();
+  const { editorRef } = useEditorRef() ?? {};
+
+  const handleClick = () => {
+    setDisabled(true);
+
+    const editorState = editorRef?.current?.getEditorState();
+
+    if (editorState) {
+      const validatedFields = validateReviewFields({ title, movieName, editorState });
+
+      if (!validatedFields.success) {
+        // Order to check should be aligned with the order of elements in the DOM
+        // title -> movieName -> editor
+        if (validatedFields.errors.title) {
+          titleRef.current?.focus();
+          emitToast(validatedFields.errors.title, 'error');
+        } else if (validatedFields.errors.movieName) {
+          movieNameRef.current?.focus();
+          emitToast(validatedFields.errors.movieName, 'error');
+        } else {
+          editorRef?.current?.focus();
+          emitToast(validatedFields.errors.content!, 'error');
+        }
+
+        setDisabled(false);
+        return;
+      }
+
+      void createReview(validatedFields.data)
+        .then(({ review }) => {
+          emitToast('리뷰 등록 완료', 'success');
+          router.push(`/review/${review.id}`);
+        })
+        .catch((error) => {
+          if (isErrorWithMessage(error)) {
+            emitToast(error.message, 'error');
+          } else {
+            // TODO: throw new Error and move to global error handler
+            console.error(error);
+            emitToast('알 수 없는 에러가 발생했습니다. 다시 시도해주세요.', 'error');
+          }
+        })
+        .finally(() => setDisabled(false));
+    }
+  };
+
+  const className = clsx(' rounded-full border bg-white px-2 py-1', {
+    'pointer-events-none': disabled,
+  });
+
+  return (
+    <button className={className} onClick={handleClick} aria-disabled={disabled}>
+      <Text>등록하기</Text>
+    </button>
+  );
+}

--- a/ui/src/lib/utils/common/error.ts
+++ b/ui/src/lib/utils/common/error.ts
@@ -1,0 +1,12 @@
+export interface ErrorWithMessage {
+  message: string;
+}
+
+export function isErrorWithMessage(error: unknown): error is ErrorWithMessage {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'message' in error &&
+    typeof error.message === 'string'
+  );
+}


### PR DESCRIPTION
#233

# Changes

- createReview api 요청을 위한 버튼입니다. 
- 요청 성공 시 추가된 리뷰 디테일 페이지로 이동합니다.
- 비어있는 필드가 있는 경우, 위에 있는 요소 부터 에러 토스트를 표시하고 포커스 시킵니다. (참고:  https://github.com/MovieReviewComment/Mr.C/pull/216#issuecomment-1985133336)