### PR TITLE
[#171] Protect route on client side

### DIFF
--- a/ui/src/lib/constants/auth.ts
+++ b/ui/src/lib/constants/auth.ts
@@ -1,0 +1,1 @@
+export const protectedPaths = ['/review/write'];


### PR DESCRIPTION
#171

# Changes

Auth Context 에서 protectedPaths 에 접근 시 유효한 토큰으로 로그인 되어있는지 확인합니다.

이전에 논의한 대로 일단은 클라이언트 사이드에서 auth 관련 로직을 모두 처리합니다.
따라서 페이지 가드 역시 클라이언트 사이드에서 이뤄집니다. 
백엔드를 통해 유효한 유저인지 확인되기 전까지의 잠깐동안 SSR 된 컴포넌트가 보여질 수 있습니다.

인증이 필요한 데이터는 애초에 서버사이드에서 다루지 않는 구조이므로, 혹시 어색할 수 있는 유저 경험외에 큰 문제는 없어보입니다.