### PR TITLE
[#266] Implement Viewer for review content

### DIFF
--- a/ui/src/components/review/server/viewer.tsx
+++ b/ui/src/components/review/server/viewer.tsx
@@ -1,0 +1,18 @@
+'use server';
+
+import dynamic from 'next/dynamic';
+
+import { getHtml } from '@/lib/utils/review/get-html';
+import { parseReviewContent } from '@/lib/utils/review/parse-review-content';
+
+export async function Viewer({ content }: { content: string }) {
+  const { serializedEditorState } = parseReviewContent(content);
+  const html = await getHtml(serializedEditorState);
+
+  const Editor = dynamic(() => import('@/editor'), {
+    ssr: false,
+    loading: () => <div className="editor" dangerouslySetInnerHTML={{ __html: html }} />,
+  });
+
+  return <Editor namespace="review-editor" isNew={false} prepopulated={serializedEditorState} />;
+}

--- a/ui/src/editor/index.tsx
+++ b/ui/src/editor/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { LexicalComposer, type InitialConfigType } from '@lexical/react/LexicalComposer';
+import type { SerializedEditorState } from 'lexical';
 
 import { Plugins } from '@/editor/plugins';
 import nodes from '@/editor/nodes';
@@ -8,8 +9,17 @@ import theme from '@/editor/theme';
 import '@/styles/editor.css';
 
 // This has to be rendered on client side only (no ssr!)
-export default function Editor({ namespace, isNew }: { namespace: string; isNew: boolean }) {
+export default function Editor({
+  namespace,
+  isNew,
+  prepopulated,
+}: {
+  namespace: string;
+  isNew: boolean;
+  prepopulated?: SerializedEditorState;
+}) {
   const initialConfig: InitialConfigType = {
+    editorState: JSON.stringify(prepopulated),
     nodes: [...nodes],
     namespace,
     onError: (error: Error) => {


### PR DESCRIPTION
Resolves #266

# Changes

Viewer 컴포넌트입니다.
headless editor로 서버사이드에서 생성된 html이 skeleton 역할을 합니다.
그 후 상호작용가능한 Editor 가 마운트 되며 갈아끼워집니다.