### PR TITLE
[#302] Add ListPlugin

### DIFF
--- a/ui/src/editor/plugins/index.tsx
+++ b/ui/src/editor/plugins/index.tsx
@@ -5,6 +5,7 @@ import { ContentEditable } from '@lexical/react/LexicalContentEditable';
 import { useEditorRef } from '@/context/editor/editor-ref-context';
 import { MarkdownShortcutPlugin } from '@/editor/plugins/markdown-shorcut';
 import { EditorRefPlugin } from '@lexical/react/LexicalEditorRefPlugin';
+import { ListPlugin } from '@lexical/react/LexicalListPlugin';
 
 function Placeholder() {
   return <div className="placeholder">Begin writing your review...</div>;
@@ -27,6 +28,7 @@ export function Plugins() {
         ErrorBoundary={LexicalErrorBoundary}
       />
       <MarkdownShortcutPlugin />
+      <ListPlugin />
       {onRef !== undefined && <EditorRefPlugin editorRef={onRef} />}
     </>
   );


### PR DESCRIPTION
#302

# Changes

리스트 관련된 동작이 올바르게 지원됩니다. 
이 플러그인 없이도 MarkDownShortcutPlugin 의 지원으로 `- `, `1. ` 같은 키입력으로 리스트로의 변환은 됩니다.

ListPlugin의 역할은 
1. Programatic 하게 `INSERT_ORDERED_LIST_COMMAND` 같은 커맨드로 리스트 노드를 추가하는 이벤트를 조작하게끔 해줍니다. (i.e. 툴바의 버튼 클릭 이벤트에 사용)
2. 리스트노드의 자식 텍스트 노드가 비어있는 상태로 엔터를 입력하면 리스트를 탈출하는 동작을 지원합니다. (아래 영상 참조)


https://github.com/MovieReviewComment/Mr.C/assets/40269597/bf182245-a543-4e9a-a255-ffd3bf43acb7



