### PR TITLE
[#302] Add MaxLengthPlugin

### DIFF
--- a/ui/src/app/(board)/review/write/page.tsx
+++ b/ui/src/app/(board)/review/write/page.tsx
@@ -10,6 +10,7 @@ import ReviewTitle from '@/components/review/client/review-title';
 
 import { EditorRefProvider } from '@/context/editor/editor-ref-context';
 import { ReviewProvider } from '@/context/review/review-context';
+import { MAX_CONTENT_LENGTH } from '@/lib/constants/review';
 
 const Editor = dynamic(() => import('@/editor'), {
   ssr: false,
@@ -49,7 +50,7 @@ export default function Page() {
               <ReviewTitle isMovieName placeholder="Movie" />
             </div>
 
-            <Editor namespace="review-editor" isNew />
+            <Editor namespace="review-editor" isNew maxLength={MAX_CONTENT_LENGTH} />
           </section>
         </main>
       </ReviewProvider>

--- a/ui/src/components/review/server/viewer.tsx
+++ b/ui/src/components/review/server/viewer.tsx
@@ -4,6 +4,7 @@ import dynamic from 'next/dynamic';
 
 import { getHtml } from '@/lib/utils/review/get-html';
 import { parseReviewContent } from '@/lib/utils/review/parse-review-content';
+import { MAX_CONTENT_LENGTH } from '@/lib/constants/review';
 
 export async function Viewer({ content }: { content: string }) {
   const { serializedEditorState } = parseReviewContent(content);
@@ -14,5 +15,12 @@ export async function Viewer({ content }: { content: string }) {
     loading: () => <div className="editor" dangerouslySetInnerHTML={{ __html: html }} />,
   });
 
-  return <Editor namespace="review-editor" isNew={false} prepopulated={serializedEditorState} />;
+  return (
+    <Editor
+      namespace="review-editor"
+      isNew={false}
+      prepopulated={serializedEditorState}
+      maxLength={MAX_CONTENT_LENGTH}
+    />
+  );
 }

--- a/ui/src/editor/index.tsx
+++ b/ui/src/editor/index.tsx
@@ -14,10 +14,12 @@ export default function Editor({
   namespace,
   isNew,
   prepopulated,
+  maxLength,
 }: {
   namespace: string;
   isNew: boolean;
   prepopulated?: SerializedEditorState;
+  maxLength?: number;
 }) {
   const initialConfig: InitialConfigType = {
     editorState: JSON.stringify(prepopulated),
@@ -34,7 +36,7 @@ export default function Editor({
     <div className="editor">
       <LexicalComposer initialConfig={initialConfig}>
         <EditorHistoryContext>
-          <Plugins />
+          <Plugins maxLength={maxLength} />
         </EditorHistoryContext>
       </LexicalComposer>
     </div>

--- a/ui/src/editor/plugins/index.tsx
+++ b/ui/src/editor/plugins/index.tsx
@@ -8,12 +8,13 @@ import { EditorRefPlugin } from '@lexical/react/LexicalEditorRefPlugin';
 import { ListPlugin } from '@lexical/react/LexicalListPlugin';
 import { HistoryPlugin } from '@/editor/plugins/history';
 import { TabIndentationPlugin } from '@lexical/react/LexicalTabIndentationPlugin';
+import { MaxLengthPlugin } from '@/editor/plugins/max-length';
 
 function Placeholder() {
   return <div className="placeholder">Begin writing your review...</div>;
 }
 
-export function Plugins() {
+export function Plugins({ maxLength }: { maxLength?: number }) {
   const { onRef } = useEditorRef() ?? {};
 
   return (
@@ -34,6 +35,7 @@ export function Plugins() {
       <HistoryPlugin />
       <TabIndentationPlugin />
       {onRef !== undefined && <EditorRefPlugin editorRef={onRef} />}
+      {maxLength && <MaxLengthPlugin maxLength={maxLength} />}
     </>
   );
 }

--- a/ui/src/editor/plugins/max-length/index.tsx
+++ b/ui/src/editor/plugins/max-length/index.tsx
@@ -1,0 +1,53 @@
+// ref: https://github.com/facebook/lexical/tree/main/packages/lexical-playground/src/plugins/MaxLengthPlugin
+import { $getSelection, $isRangeSelection, EditorState, RootNode } from 'lexical';
+import { useEffect } from 'react';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { trimTextContentFromAnchor } from '@lexical/selection';
+import { $restoreEditorState } from '@lexical/utils';
+
+import { useToast } from '@/context/common/toast-context';
+
+import { useDebouncedCallback } from '@/hooks/common/use-debounced-callback';
+
+export function MaxLengthPlugin({ maxLength }: { maxLength: number }): null {
+  const [editor] = useLexicalComposerContext();
+
+  const { emitToast } = useToast();
+  const debouncedEmitToast = useDebouncedCallback(emitToast, 300);
+
+  useEffect(() => {
+    let lastRestoredEditorState: EditorState | null = null;
+
+    return editor.registerNodeTransform(RootNode, (rootNode: RootNode) => {
+      const selection = $getSelection();
+      if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
+        return;
+      }
+
+      const prevEditorState = editor.getEditorState();
+      const prevTextContentSize = prevEditorState.read(() => rootNode.getTextContentSize());
+      const textContentSize = rootNode.getTextContentSize();
+
+      if (prevTextContentSize !== textContentSize) {
+        const delCount = textContentSize - maxLength;
+        const anchor = selection.anchor;
+
+        if (delCount > 0) {
+          // TODO: pass this as onMaxLength prop
+          debouncedEmitToast(`리뷰는 ${maxLength}자를 넘을 수 없습니다.`, 'error');
+
+          // Restore the old editor state instead if the last
+          // text content was already at the limit.
+          if (prevTextContentSize === maxLength && lastRestoredEditorState !== prevEditorState) {
+            lastRestoredEditorState = prevEditorState;
+            $restoreEditorState(editor, prevEditorState);
+          } else {
+            trimTextContentFromAnchor(editor, anchor, delCount);
+          }
+        }
+      }
+    });
+  }, [editor, maxLength, debouncedEmitToast]);
+
+  return null;
+}

--- a/ui/src/lib/constants/review.ts
+++ b/ui/src/lib/constants/review.ts
@@ -1,2 +1,2 @@
 export const MAX_TITLE_LENGTH = 100;
-export const MAX_CONTENT_LENGTH = 2000;
+export const MAX_CONTENT_LENGTH = 5000;


### PR DESCRIPTION
#302

# Changes

Lexical Playground 의 MaxLengthPlugin 을 참고했습니다. (참고: [MaxLengthPlugin](https://github.com/facebook/lexical/tree/main/packages/lexical-playground/src/plugins/MaxLengthPlugin))

maxLength 를 초과한 글자 수 입력이 불가능합니다.